### PR TITLE
Add in handling for unaryExpr operators

### DIFF
--- a/nCompiler/R/compile_aaa_operatorLists.R
+++ b/nCompiler/R/compile_aaa_operatorLists.R
@@ -130,9 +130,12 @@ assignOperatorDef(
       returnTypeCode = returnTypeCodes$promoteNoLogical),
     eigenImpl = list(
       handler = 'Reduction',
-      method = TRUE)
+      method = TRUE),
+    cppOutput = list()
   )
 )
+updateOperatorDef('max', 'cppOutput', 'cppString', 'maximum')
+updateOperatorDef('min', 'cppOutput', 'cppString', 'minimum')
 
 assignOperatorDef(
   c('pmin', 'pmax'),
@@ -143,11 +146,12 @@ assignOperatorDef(
       returnTypeCode = returnTypeCodes$promoteNoLogical),
     eigenImpl = list(
       handler = 'cWiseBinary',
-      method = TRUE)
+      method = TRUE),
+    cppOutput = list()
   )
 )
-updateOperatorDef('pmax', 'eigenImpl', 'cppName', 'cwiseMax')
-updateOperatorDef('pmin', 'eigenImpl', 'cppName', 'cwiseMin')
+updateOperatorDef('pmax', 'cppOutput', 'cppString', 'cwiseMax')
+updateOperatorDef('pmin', 'cppOutput', 'cppString', 'cwiseMin')
 
 assignOperatorDef(
   'eigencast',
@@ -261,12 +265,12 @@ assignOperatorDef(
 )
 
 assignOperatorDef(
-  c('atan'),
+  c('atan', 'logit'),
   list(
     help = 'Example help entry',
     labelAbstractTypes = list(
       handler = 'UnaryCwise',
-      returnTypeCode = returnTypeCodes$promoteNoLogical),
+      returnTypeCode = returnTypeCodes$double),
     eigenImpl = list(
       toEigen = 'Yes',
       handler = 'cWiseUnary_external',
@@ -338,9 +342,9 @@ assignOperatorDef(
     eigenImpl = list(
       toEigen = 'Yes',
       handler = 'cWiseByScalar', ## Eigen::Tensor requires the rhs of pow to be scalar
-      cppName = 'pow',
       method = TRUE),
     cppOutput = list(
+      cppString = 'pow',
       handler = '')
   )
 )

--- a/nCompiler/R/compile_generateCpp.R
+++ b/nCompiler/R/compile_generateCpp.R
@@ -120,6 +120,14 @@ inGenCppEnv(
 )
 
 inGenCppEnv(
+  getCppString <- function(code) {
+    opString <- getOperatorDef(code$name, 'cppOutput', 'cppString')
+    if (is.null(opString)) return(code$name)
+    opString
+  }
+)
+
+inGenCppEnv(
     AsIs <- function(code, symTab) {
         paste0(exprName2Cpp(code, symTab),
                '(', paste0(unlist(lapply(code$args,
@@ -175,9 +183,7 @@ inGenCppEnv(
             firstPart <- paste0('flex_(', firstPart, ')')
         }
 
-        opString <- getOperatorDef(code$name, 'cppOutput', 'cppString')
-        if (is.null(opString)) opString <- paste0(" ", code$name, " ")
-
+        opString <- getCppString(code)
         output <- paste0(firstPart, opString, secondPart)
 
         if(useParens)
@@ -272,16 +278,16 @@ inGenCppEnv(
   ## This differs from old system
   ## Method(A, foo, x) -> A.foo(x)
   Method <- function(code, symTab) {
-    paste0( '(', 
-            compile_generateCpp(code$args[[1]], symTab),
-            ').', paste0(code$args[[2]]$name,
-                         '(', 
-                         paste0(unlist(lapply(code$args[-c(1, 2)],
-                                              compile_generateCpp, 
-                                              symTab) ), 
-                                collapse = ', '),
-                         ')' )
+    obj <- paste0('(', compile_generateCpp(code$args[[1]], symTab), ').')
+    opString <- getCppString(code$args[[2]])
+    methodCall <- paste0(
+      opString, '(',
+      paste0(
+        unlist(lapply(code$args[-c(1, 2)], compile_generateCpp, symTab)),
+        collapse = ', '
+      ), ')'
     )
+    paste0(obj, methodCall)
   }
 )
 

--- a/nCompiler/R/compile_labelAbstractTypes.R
+++ b/nCompiler/R/compile_labelAbstractTypes.R
@@ -338,11 +338,10 @@ inLabelAbstractTypesEnv(
             arg <- code$args[[1]]
 
             argType <- arg$type
-            nDim <- argType$nDim
-            ## If we need different unary operators to have different scalar return types,
-            ## we can add a field to the handlerInfo for that.  It could default to double.
-            resultScalarType <- 'double'
-            resultType <- symbolBasic$new(nDim = nDim,
+            resultScalarType <- arithmeticOutputType(
+              argType$type, returnTypeCode = handlingInfo$returnTypeCode
+            )
+            resultType <- symbolBasic$new(nDim = argType$nDim,
                                           type = resultScalarType)
             code$type <- resultType
             invisible(NULL)
@@ -459,13 +458,13 @@ sizeProxyForDebugging <- function(code, symTab, auxEnv) {
 
 ## promote numeric output to most information-rich type, double > integer > logical
 ## Note this will not be correct for logical operators, where output type should be logical
-arithmeticOutputType <- function(t1, t2, returnTypeCode = NULL) {
+arithmeticOutputType <- function(t1, t2 = NULL, returnTypeCode = NULL) {
   if (!is.null(returnTypeCode) && returnTypeCode %in% c(1L, 2L, 3L))
     return(names(returnTypeCodes)[[returnTypeCode]])
   if (t1 == 'double') return('double')
-  if (t2 == 'double') return('double')
+  if (!is.null(t2) && t2 == 'double') return('double')
   if (t1 == 'integer') return('integer')
-  if (t2 == 'integer') return('integer')
+  if (!is.null(t2) && t2 == 'integer') return('integer')
   if (returnTypeCode == 5L) return('integer') ## no logical
   return('logical')
 }

--- a/nCompiler/R/cppDefs_nFunction.R
+++ b/nCompiler/R/cppDefs_nFunction.R
@@ -31,6 +31,7 @@ cpp_nFunctionClass <- R6::R6Class(
                                  nCompilerIncludeFile("nCompiler_Eigen.h"),
                                   '<Rmath.h>',
                                   '<math.h>',
+                                  nCompilerIncludeFile("cWiseUnary_external.cpp"),
                                   #nCompilerIncludeFile("EigenTypedefs.h"),
                                   #nCompilerIncludeFile("Utils.h"),
                                   #nCompilerIncludeFile("accessorClasses.h"),

--- a/nCompiler/inst/include/nCompiler/cWiseUnary_external.cpp
+++ b/nCompiler/inst/include/nCompiler/cWiseUnary_external.cpp
@@ -1,0 +1,1 @@
+double logit(double x) {return log(x/(1.-x));}


### PR DESCRIPTION
This PR adds back in handling for unaryExpr operators which was lost in the transition from nimbleCompiler to nCompiler. I made some updates and changes as well, so a quick code review may be in order.