### PR TITLE
Add VectorReturnType labelAbstractTypes handler

### DIFF
--- a/nCompiler/R/compile_labelAbstractTypes.R
+++ b/nCompiler/R/compile_labelAbstractTypes.R
@@ -798,6 +798,16 @@ inLabelAbstractTypesEnv(
     }
 )
 
+inLabelAbstractTypesEnv(
+  ## recurse and set code type via setReturnType()
+  VectorReturnType <- function(code, symTab, auxEnv, handlingInfo) {
+    inserts <- recurse_labelAbstractTypes(code, symTab, auxEnv, handlingInfo)
+    returnType <- setReturnType(handlingInfo, code$args[[1]]$type$type)
+    code$type <- symbolBasic$new(nDim = 1, type = returnType)
+    invisible(inserts)
+  }
+)
+
 sizeProxyForDebugging <- function(code, symTab, auxEnv) {
   browser()
   origValue <- nOptions$debugSizeProcessing


### PR DESCRIPTION
* VectorReturnType recurses, sets code$type$nDim to 1 and sets code$type$type
  via the setReturnType() util