### PR TITLE
Fix setup_nCompLocal

### DIFF
--- a/nCompiler/R/local_DLL.R
+++ b/nCompiler/R/local_DLL.R
@@ -63,29 +63,28 @@ createLocalDLLpackage <- function(dir = '.',
                   showOutput = FALSE)
   options(rcpp.warnNoExports = currentWarn)
   ## Navigate through Rcpp's cache directory structure:
-  cacheDir1 <- getOption("rcpp.cache.dir", tempdir()) ## from sourceCpp
-  cacheDir1Files <- list.files(cacheDir1)
+  cacheDir1 <- getOption("rcpp.cache.dir", tempdir()) ## where sourceCpp places files
+  cacheDir1Files <- list.files(cacheDir1, full.names = TRUE)
+  ## Determine the most recent directory name with "sourceCpp" in it.
   sourceCppDir1 <- cacheDir1Files[ grepl("sourceCpp", cacheDir1Files)]
   if (length(sourceCppDir1) > 1) {
     cppDir1_mtime <- file.mtime(sourceCppDir1)
     sourceCppDir1 <- sourceCppDir1[which.max(cppDir1_mtime)]
   }
-  cacheDir2 <- file.path(cacheDir1, sourceCppDir1)
-  cacheDir2Files <- list.files(cacheDir2)
-  sourceCppDir2 <- cacheDir2Files[ grepl("sourcecpp", cacheDir2Files)]
-  if (length(sourceCppDir2) > 1) {
-    cppDir2_mtime <- file.mtime(sourceCppDir2)
-    sourceCppDir2 <- sourceCppDir2[which.max(cppDir2_mtime)]
+  sourceCppDir1Files <- list.files(sourceCppDir1, full.names = TRUE)
+  ## Determine the most recent subdirectory with the name "sourcecpp" (lower-case c) in it
+  sourcecppDir2 <- sourceCppDir1Files[ grepl("sourcecpp", sourceCppDir1Files)]
+  if (length(sourcecppDir2) > 1) {
+    cppDir2_mtime <- file.mtime(sourcecppDir2)
+    sourcecppDir2 <- sourcecppDir2[which.max(cppDir2_mtime)]
   }
-  # We end up with the final (3rd) cacheDir
-  cacheDir <- file.path(cacheDir2, sourceCppDir2)
   ## Build static library from the .o files left by Rcpp.
   ## This will need to be updated for windows
   if(.Platform$OS.type == "windows")
     message("Need to update the 'ar' call in createLocalDLLpackage for Windows.")
   system2("ar", c("rcs",
                   file.path(staticLibPath, "libnCompLocal.a"),
-                  file.path(cacheDir, "loadedObjectEnv.o")))
+                  file.path(sourcecppDir2, "loadedObjectEnv.o")))
 }
 
 cleanupLocalDLLpackage <- function(dir = '.') {

--- a/nCompiler/inst/nCompLocal_files/loadedObjectEnv.cpp
+++ b/nCompiler/inst/nCompLocal_files/loadedObjectEnv.cpp
@@ -1,5 +1,5 @@
-// This file is intended to be copied to the inst/staticLib directory of the nCompLocal packaage.
-// nimCompLocal is a small package that nComp will install.
+// This file is intended to be copied to the inst/staticLib directory of the nCompLocal package.
+// nCompLocal is a small package that nComp will install.
 #include "nCompiler/loadedObjectEnv.h"
 
 // [[Rcpp::depends(nCompiler)]]


### PR DESCRIPTION
This PR fixes two issues in setup_nCompLocal (specifically in the helper function createLocalDLLpackage). 

One issue had to do with using grepl to iteratively identify subdirectories. There was a case where multiple directories would be chosen when only 1 is required. Now the function checks which of these were written most recently using file.mtime().

Another issue had to do with a pkg.kitten function being flagged for export in NAMESPACE, which was causing an error on the call to install.packages(). I fixed this by wiping the NAMESPACE file blank (this had been the only line in it).