### PR TITLE
Make nClass interfaces (R6 classes) use the same scoping for compiled as uncompiled

### DIFF
--- a/nCompiler/R/NC_FullCompiledInterface.R
+++ b/nCompiler/R/NC_FullCompiledInterface.R
@@ -55,7 +55,7 @@
 #' @export
 build_compiled_nClass <- function(NCgenerator,
                                   newCobjFun,
-                                  env = parent.frame(),
+                                  env = NCgenerator$parent_env,
                                   quoted = FALSE) {
   # One might wonder if we can have an R6 class created here to
   # interface with a compiled C++ class be established with

--- a/nCompiler/R/nCompile.R
+++ b/nCompiler/R/nCompile.R
@@ -670,8 +670,8 @@ nCompile_finish_nonpackage <- function(units,
           } else {
             if(expect_createFromR[i]) createFromR_fun <- compiledFuns[[iRes]]
             R6interfaces[[i]] <- try(build_compiled_nClass(units[[i]],
-                                                            createFromR_fun,
-                                                            env = resultEnv))
+                                                            createFromR_fun))
+                                                           # env = resultEnv))
             if(inherits(R6interfaces[[i]], "try-error")) {
               warning(paste0("There was a problem building a full nClass interface for ", exportNames[i], "."))
               R6interfaces[[i]] <- NULL


### PR DESCRIPTION
This PR sets the `parent_env` of the R6 class generated to interface to a compiled nClass object to achieve the same scoping as the uncompiled nClass. There is one environment layer in between that provides the chance to place objects that will be found before scoping reaches to the uncompiled nClass `parent_env` when looking for a name. This change means that if an Rpublic function (including initialize) relies on scoping to find  a non-member object, that will work in the compiled interface class as well. For example, this is relevant if an nClass is created in a function and uses local variables in that function, to be found by lexical scoping.

This has no effect and is much less relevant for package development anyway. In that case, typically, both the nClass and its compiler R6 interface would have `parent_env` that is the package namespace. In the `writePackage` scheme, the R6 interface class code goes into the package source code and then does not have its parent env manipulated.