### PR TITLE
add `nCat` operator

### DIFF
--- a/nCompiler/NAMESPACE
+++ b/nCompiler/NAMESPACE
@@ -67,6 +67,7 @@ export(new.loadedObjectEnv) ## needed for Rcpp::Function access in loadedObjectE
 export(new.loadedObjectEnv_full) ## ditto
 export(nBacksolve)
 export(nC) ## c()
+export(nCat) ## cat()
 export(nClassClass)
 export(nCompile_nClass)
 export(nCompile_nFunction)

--- a/nCompiler/R/Rexecution.R
+++ b/nCompiler/R/Rexecution.R
@@ -45,6 +45,8 @@ loggam <- lgamma
 logfact <- lfactorial
 #' @export
 nC <- c
+#' @export
+nCat <- cat
 
 #' Creates numeric, integer or logical vectors for use in nFunctions
 #'

--- a/nCompiler/R/changeKeywords.R
+++ b/nCompiler/R/changeKeywords.R
@@ -31,7 +31,8 @@ nKeyWords <- list(copy = 'nCopy',
                   backsolve = 'nBacksolve',
                   logdet = 'nLogdet',
                   var = 'nVar',
-                  sd = 'nSd'
+                  sd = 'nSd',
+                  cat = 'nCat'
                   )
 
 nf_changeKeywords <- function(code){

--- a/nCompiler/R/compile_aaa_operatorLists.R
+++ b/nCompiler/R/compile_aaa_operatorLists.R
@@ -1206,13 +1206,13 @@ assignOperatorDef(
 )
 
 assignOperatorDef(
-  'nimCat',
+  'nCat',
   list(
     labelAbstractTypes = list(
-      handler = 'nimCat'
+      handler = 'nCat'
     ),
     cppOutput = list(
-      handler = 'nimCat'
+      handler = 'nCat'
     )
   )
 )

--- a/nCompiler/R/compile_generateCpp.R
+++ b/nCompiler/R/compile_generateCpp.R
@@ -600,9 +600,16 @@ inGenCppEnv(
 )
 
 inGenCppEnv(
-    nimCat <- function(code, symTab) {
-        paste0("std::cout << ", 
-               compile_generateCpp(code$args[[1]], symTab)
-               )
+    nCat <- function(code, symTab) {
+        ## paste0("std::cout << ", paste0(unlist(lapply(code$args, compile_generateCpp, symTab, asArg = TRUE) ), collapse = '<<'))
+        if(is.null(get_nOption('digits'))) {
+            paste0("_nCompiler_global_output << ",
+                   paste0(unlist(lapply(code$args, compile_generateCpp, symTab, asArg = TRUE) ), collapse = '<<'),
+                   '; nCompiler_print_to_R(_nCompiler_global_output)')
+        } else {
+            paste0('_nCompiler_global_output.precision(', get_nOption('digits'), '); _nCompiler_global_output << std::fixed << ',
+                   paste0(unlist(lapply(code$args, compile_generateCpp, symTab, asArg = TRUE) ), collapse = '<<'),
+                   '; nCompiler_print_to_R(_nCompiler_global_output)')
+        }
     }
 )

--- a/nCompiler/R/compile_labelAbstractTypes.R
+++ b/nCompiler/R/compile_labelAbstractTypes.R
@@ -1784,7 +1784,7 @@ inLabelAbstractTypesEnv(
 )
 
 inLabelAbstractTypesEnv(
-    nimCat <- function(code, symTab, auxEnv, handlingInfo) {
+    nCat <- function(code, symTab, auxEnv, handlingInfo) {
         inserts <- recurse_labelAbstractTypes(code, symTab, auxEnv, handlingInfo)
         invisible(inserts)
     }

--- a/nCompiler/R/options.R
+++ b/nCompiler/R/options.R
@@ -52,7 +52,8 @@ updateDefaults <- function(defaults, control) {
     sourceCpp_verbose = FALSE,
     nimble = FALSE, ## ensure all backward compatibility
     dropSingleSizes = FALSE, ## backward compatibility
-    useSafeDeparse = TRUE
+    useSafeDeparse = TRUE,
+    digits = NULL
   )
 )
 

--- a/nCompiler/inst/include/nCompiler/utils.h
+++ b/nCompiler/inst/include/nCompiler/utils.h
@@ -1,3 +1,17 @@
+#include<iostream>
+#include<sstream>
+
+#define PRINTF Rprintf
+
+std::ostringstream _nCompiler_global_output;
+
+void nCompiler_print_to_R(std::ostringstream &input) {
+  PRINTF("%s", input.str().c_str());
+  input.str("");
+  input.clear();
+}
+
+
 #ifndef _NC_UTILS_
 #define _NC_UTILS_
 


### PR DESCRIPTION
This provides full functionality for `nCat`, mimicing `nimCat` in `nimble`.

A few notes:
- I should add some tests. Everything I've tested so far works fine, including using with mathemetical expressions like `x+y`.
- @perrydv the C++ defs for `_nCompiler_global_output` etc. are in `utils.h`. There may well be someplace else they should be.
- We should discuss adding `nPrint`, which simply adds `\n`. I think there is an argument for not providing it (or making it an alias for `nCat` (for back compatibility)) since `print()` in R is a somewhat different beast than `cat`, as it is an S3 generic.