### PR TITLE
WIP: Allow private R and C members in nClass

### DIFF
--- a/nCompiler/R/NC_CompilerClass.R
+++ b/nCompiler/R/NC_CompilerClass.R
@@ -50,7 +50,7 @@ NC_CompilerClass <- R6::R6Class(
 
       methodNames <- myNCinternals$methodNames
       for(m in methodNames) {
-        thisMethod <- NCgenerator$public_methods[[m]]
+        thisMethod <- c(NCgenerator$public_methods, NCgenerator$private_methods)[[m]]
         thisName <- NULL
         if(isConstructor(thisMethod)) {
           #NFinternals(thisMethod)$cpp_code_name <- self$name

--- a/nCompiler/R/NC_Utils.R
+++ b/nCompiler/R/NC_Utils.R
@@ -84,7 +84,7 @@ NCinternals <- function(x) {
 
 # Utility function to allow searching up an inheritance
 # ladder to find a method.
-NC_find_method <- function(NCgenerator, name, inherits=TRUE) {
+NC_find_method <- function(NCgenerator, name, inherits=TRUE, includePrivate = TRUE) {
   if(!isNCgenerator(NCgenerator))
     stop("Input must be a nClass generator.")
   current_NCgen <- NCgenerator
@@ -92,7 +92,10 @@ NC_find_method <- function(NCgenerator, name, inherits=TRUE) {
   method <- NULL
   while(!done) {
     if(name %in% NCinternals(current_NCgen)$methodNames) {
-      method <- current_NCgen$public_methods[[name]]
+      method <- c(current_NCgen$public_methods,
+                  if(includePrivate) current_NCgen$private_methods else NULL)[[name]]
+      if(!includePrivate && name %in% names(current_NCgen$private_methods))
+          warning(name, " is a private method not available in the calling context")  # TODO: use new messaging system.
       done <- TRUE
     } else {
       if(inherits)  {

--- a/nCompiler/R/NF_derivs.R
+++ b/nCompiler/R/NF_derivs.R
@@ -129,7 +129,7 @@ setup_wrt <- function(nFxn = NA, dropArgs = NA, wrt = NULL, NC = NULL) {
     fxn <- eval(fxnCall, envir = parent.frame())
     fxnName <- fxnCall[[3]]
     if (!is.character(fxnName)) fxnName <- deparse(fxnName)
-    nf <- NC$public_methods[[fxnName]]
+    nf <- c(NC$public_methods, NC$private_methods)[[fxnName]]
     fxnArgs <- NFinternals(nf)$argSymTab$symbols
 
   } else if (is.call(fxnCall) && fxnCall[[1]] == 'method') {
@@ -154,10 +154,10 @@ setup_wrt <- function(nFxn = NA, dropArgs = NA, wrt = NULL, NC = NULL) {
 
     fxnName <- fxnCall[[3]]
 
-    nf <- NC$public_methods[[fxnName]]
+    nf <- c(NC$public_methods, NC$private_methods)[[fxnName]]
     if (is.null(nf))
       stop(paste0(
-        "The 'NC' argument provided to 'setup_wrt' has no public method named ",
+        "The 'NC' argument provided to 'setup_wrt' has no method named ",
         fxnName, "."))
 
     fxnArgs <- NFinternals(nf)$argSymTab$symbols
@@ -575,7 +575,7 @@ nDerivs_full <- function(fxnCall = NULL, order = c(0, 1, 2), dropArgs = NA,
 
   fxnName <- fxnCall[[1]][[3]]
   if (is.symbol(fxnName)) fxnName <- deparse(fxnName)
-  nf <- NC$public_methods[[fxnName]]
+  nf <- c(NC$public_methods, NC$private_methods)[[fxnName]]
   fxnArgs <- NFinternals(nf)$argSymTab$symbols
   fxnCall[[1]] <- derivFxnCall
   fxnCall$order <- order
@@ -603,10 +603,10 @@ nDerivs_generic <- function(fxnCall = NULL, order = c(0, 1, 2), dropArgs = NA,
       "The 'NC' argument to 'nDerivs' must be an nClass generator (returned",
       "from a call to 'nClass')."))
 
-  nf <- NC$public_methods[[fxnName]]
+  nf <- c(NC$public_methods, NC$private_methods)[[fxnName]]
   if (is.null(nf))
     stop(paste0(
-      "The 'NC' argument provided to 'nDerivs' has no public method named ",
+      "The 'NC' argument provided to 'nDerivs' has no method named ",
       fxnName, "."))
 
   fxnArgs <- NFinternals(nf)$argSymTab$symbols

--- a/nCompiler/R/compile_labelAbstractTypes.R
+++ b/nCompiler/R/compile_labelAbstractTypes.R
@@ -306,6 +306,15 @@ inLabelAbstractTypesEnv(
         obj_internals <- NULL
       } else {  ## Is RHS a field?
         symbol <- NCinternals(code$args[[1]]$type$NCgenerator)$symbolTable$getSymbol(innerName, inherits=TRUE)
+        if(!is.null(symbol)) {  # Check for improper use of private field.
+          if(!(inherits(auxEnv$where, "R6ClassGenerator") && auxEnv$where$class &&
+               auxEnv$where$classname == code$args[[1]]$type$NCgenerator$classname) &&
+             NCinternals(code$args[[1]]$type$NCgenerator)$compileInfo$isPrivate[symbol$name])
+             stop(exprClassProcessingErrorMsg(
+                  code,
+                  paste0(nDeparse(code$args[[2]]), " is a private field.")
+              ), call. = FALSE)
+        }
         if(is.null(symbol))
           stop(exprClassProcessingErrorMsg(
             code,

--- a/nCompiler/R/compile_labelAbstractTypes.R
+++ b/nCompiler/R/compile_labelAbstractTypes.R
@@ -282,7 +282,10 @@ inLabelAbstractTypesEnv(
       ## 1. Check if RHS is a method
       ## 2. Check if RHS is a field
       innerName <- code$args[[2]]$name
-      method <- NC_find_method(code$args[[1]]$type$NCgenerator, innerName, inherits=TRUE)
+      ## Calling context must be the same class as the method being invoked.
+      includePrivate <- inherits(auxEnv$where, "R6ClassGenerator") && auxEnv$where$class &&
+        auxEnv$where$classname == code$args[[1]]$type$NCgenerator$classname
+      method <- NC_find_method(code$args[[1]]$type$NCgenerator, innerName, inherits=TRUE, includePrivate = includePrivate)
       if(!is.null(method)) { ## Is RHS a method?
         obj_internals <- NFinternals(method)
         returnSym <- symbolNF$new(

--- a/nCompiler/tests/testthat/nClass_tests/test-private.R
+++ b/nCompiler/tests/testthat/nClass_tests/test-private.R
@@ -1,0 +1,183 @@
+test_that("Classes with private members -- basic usage", {
+
+    nc1 <- nClass(
+        Rpublic = list(
+            Rv = 2,
+            Rmethod = function(x) Rmethod2(x),
+            R_setRv2 = function(x) Rv2 <<- x,   # TODO: we may need to document need for `<<-`.
+            R_getRv2 = function() return(Rv2)
+        ),
+        Rprivate = list(
+            Rv2 = 2,
+            Rmethod2 = function(x) x+Rv2),
+        Cpublic = list(
+            Cv = 'numericScalar',
+            Cmethod = nFunction(
+                fun = function(x) {
+                    return(Cmethod2(x))
+                },
+                argTypes = list(x = 'numericScalar'),
+                returnType = 'numericScalar'
+            ),
+            Cset_Cv2 = nFunction(
+                fun = function(x) {
+                    Cv2 <<- x                  # TODO: we may need to document need for `<<-`.
+                },
+                argTypes = list(x = 'numericScalar')
+            ),
+            Cget_Cv2 = nFunction(
+                fun = function() {
+                    return(Cv2)
+                }, returnType = 'numericScalar'
+            )
+        ),
+        Cprivate = list(
+            Cv2 = 'numericScalar',
+            Cmethod2 = nFunction(
+                fun = function(x) {
+                    return(x + Cv2)
+                },
+                argTypes = list(x = 'numericScalar'),
+                returnType = 'numericScalar'
+            )
+        )
+    )
+
+    ## Uncompiled operations.
+    
+    Robj <- nc1$new()
+    expect_identical(Robj$Rv, 2)
+    expect_identical(Robj$Rv2, NULL)  # private, so not found
+    expect_identical(Robj$Cv, "numericScalar")
+    expect_identical(Robj$Cv2, NULL)  # private, so not found
+    expect_identical(Robj$Rmethod2, NULL)
+    expect_identical(Robj$Cmethod2, NULL)
+    Robj$Rv <- 5
+    expect_identical(Robj$Rv, 5)
+    expect_error(Robj$Rv2 <- 5, "cannot add bindings to a locked environment")
+
+    Robj$R_setRv2(77)
+    expect_identical(Robj$R_getRv2(), 77)
+    expect_identical(Robj$Rmethod(3), 80)
+
+    Robj$Cv <- 55
+    expect_identical(Robj$Cv, 55)
+    
+    Robj$Cset_Cv2(33)
+    expect_identical(Robj$Cget_Cv2(), 33)
+
+    expect_identical(Robj$Cmethod(12), 45)
+    
+    ## Compiled operations.
+    
+    cnc1 <- nCompile(nc1)
+    Cobj <- cnc1$new()     
+    
+    expect_identical(Cobj$Rv, 2)
+    expect_identical(Cobj$Rv2, NULL)  # private, so not found
+    expect_identical(Cobj$Cv2, NULL)  # private, so not found
+    expect_identical(Cobj$Rmethod2, NULL)
+    expect_identical(Cobj$Cmethod2, NULL)
+    Cobj$Rv <- 5
+    expect_identical(Cobj$Rv, 5)
+    expect_error(Cobj$Rv2 <- 5, "cannot add bindings to a locked environment")
+
+    Cobj$R_setRv2(77)
+    expect_identical(Cobj$R_getRv2(), 77)
+    expect_identical(Cobj$Rmethod(3), 80)
+
+    Cobj$Cset_Cv2(88)
+    expect_identical(Cobj$Cget_Cv2(), 88)
+
+    expect_identical(Cobj$Cmethod(12), 100)
+
+})
+
+test_that("Access to private members", {
+    
+    nc1 <- nClass(
+        Cpublic = list(
+            Cv = 'numericScalar',
+            Cmethod = nFunction(
+                fun = function(x) {
+                    return(Cmethod2(x))
+                },
+                argTypes = list(x = 'numericScalar'),
+                returnType = 'numericScalar'
+            ),
+            Cset_Cv2 = nFunction(
+                fun = function(x) {
+                    Cv2 <<- x                
+                },
+                argTypes = list(x = 'numericScalar')
+            ),
+            Cget_Cv2 = nFunction(
+                fun = function() {
+                    return(Cv2)
+                }, returnType = 'numericScalar'
+            )
+        ),
+        Cprivate = list(
+            Cv2 = 'numericScalar',
+            Cmethod2 = nFunction(
+                fun = function(x) {
+                    return(x + Cv2)
+                },
+                argTypes = list(x = 'numericScalar'),
+                returnType = 'numericScalar'
+            )
+        )
+    )
+
+    ## Can't access private members from external function.
+    myfun <- nFunction(
+        fun = function(obj, x) {
+            return(obj$Cmethod2(x))
+        }, argTypes = list(obj = 'nc1', x='numericScalar'),
+        returnType = 'numericScalar'
+    )
+    ## We get a WARN in testing output from this. Should clean things up if possible.
+    expect_error(cmyfun <- nCompile(myfun), "could not be found")
+
+    ## Can't access private members from objects of a different class.
+    ncOuter <- nClass(
+        Cpublic = list(
+            Cfoo = nFunction(
+                fun = function(obj, x) {
+                    return(obj$Cmethod2(x))
+                },
+                argTypes = list(obj = 'nc1', x='numericScalar'),
+                returnType = 'numericScalar'
+            )
+        )
+    )
+   
+    expect_error(cncOuter <- nCompile(ncOuter), "could not be found")
+
+    ## Can access private members from separate objects of the same class.
+    nc1 <- nClass(
+        Cpublic = list(
+            Cmethod = nFunction(
+                fun = function(obj, x) {
+                    return(obj$Cmethod2(x))
+                },
+                argTypes = list(obj = 'nc1', x = 'numericScalar'),
+                returnType = 'numericScalar'
+            )
+        ),
+        Cprivate = list(
+            Cmethod2 = nFunction(
+                fun = function(x) {
+                    return(x + 3)
+                },
+                argTypes = list(x = 'numericScalar'),
+                returnType = 'numericScalar'
+            )
+        )
+    )
+    cnc1 <- nCompile(nc1)
+    Cobj1 <- cnc1$new()
+    Cobj2 <- cnc1$new()
+    expect_identical(Cobj2$Cmethod(Cobj1, 5), 8)
+    
+})


### PR DESCRIPTION
I think this is reasonably solid/complete, including testing. 

Some comments:
- I did not set activeBindings for Cprivate fields. I think that makes sense, but it means that `print(Cobj)` in R won't show that a Cprivate field even exists. 
- I do error-trap attempts to improperly access private members from outside a class. 

Some gaps:
- [ ] I did not deal with private members in `cppDefs_TBB.R` as I haven't wrapped my head around `cppParallelBodyClass`.
- [ ] There is no testing for derivs of private members.


