### PR TITLE
Have `set_nOption` return invisibly

### DIFF
--- a/nCompiler/R/options.R
+++ b/nCompiler/R/options.R
@@ -75,7 +75,7 @@ set_nOption <- function(x, value, listName = NULL) {
       .nOptions[[listName]] <- list() # overwrite any existing object
     .nOptions[[listName]][[x]] <- value
   }
-  value
+  invisible(value)
 }
 
 #' Get nCompiler Option


### PR DESCRIPTION
I don't think we want the value printed when `set_nOption` is called. 

@perrydv ok if I merge this in?