### PR TITLE
Fix and extend parallel_reduce functionality

### DIFF
--- a/nCompiler/R/Rexecution.R
+++ b/nCompiler/R/Rexecution.R
@@ -14,6 +14,18 @@ parallel_for <- function(index, range, body, ...) {
 
 #' @export
 parallel_reduce <- function(f, x, init, ...) {
+  if(is.character(f)) {  # Not clear how to convert to char ...
+    operatorDef <- operatorDefEnv[[f]]
+    if(!is.null(operatorDef) && is.null(operatorDef$reduction))
+        stop("`", f, "` is not a valid reduction function/operator")
+  }
+  if(missing(init)) {
+    if(!is.character(f) || is.null(operatorDef) || is.null(operatorDef$reduction))
+      stop("`init` argument is missing and no default value provided for reduction function/operator")
+    init <- operatorDef$reduction
+  }
+  if(identical(f, "pairmin")) f <- "pmin"
+  if(identical(f, "pairmax")) f <- "pmax"
   Reduce(f, x, init)
 }
 

--- a/nCompiler/R/compile_aaa_operatorLists.R
+++ b/nCompiler/R/compile_aaa_operatorLists.R
@@ -473,9 +473,11 @@ assignOperatorDef(
           )
         ),
         cppOutput = list(
-          handler = 'BinaryOrUnary')
+          handler = 'BinaryOrUnary'),
+        reduction = 0
     )
 )
+updateOperatorDef('-', 'reduction', val = NULL)
 
 assignOperatorDef(
   c('inprod'),
@@ -522,11 +524,13 @@ assignOperatorDef(
     labelAbstractTypes = list(
         handler = 'BinaryCwise',
         returnTypeCode = returnTypeCodes$promoteNoLogical),
-    cppOutput = list()
+    cppOutput = list(),
+    reduction = Inf
   )
 )
 updateOperatorDef('pairmax', 'cppOutput', 'cppString', 'std::max')
 updateOperatorDef('pairmin', 'cppOutput', 'cppString', 'std::min')
+updateOperatorDef('pairmax', 'reduction', val = -Inf)
 
 assignOperatorDef(
   c('pmin', 'pmax'),
@@ -902,7 +906,8 @@ assignOperatorDef(
       )
     ),
     cppOutput = list(
-      handler = 'MidOperator')
+      handler = 'MidOperator'),
+    reduction = 1
   )
 )
 

--- a/nCompiler/R/compile_eigenization.R
+++ b/nCompiler/R/compile_eigenization.R
@@ -5,7 +5,8 @@
 eigenizeUseArgs <- c(
     list(
         setWhich = c(FALSE, TRUE),
-        setRepVectorTimes = c(FALSE, TRUE, TRUE)
+        setRepVectorTimes = c(FALSE, TRUE, TRUE),
+        parallel_reduce = c(FALSE, TRUE, TRUE)
         ))
 
 eigenizeEnv <- new.env()

--- a/nCompiler/R/compile_finalTransformations.R
+++ b/nCompiler/R/compile_finalTransformations.R
@@ -128,7 +128,7 @@ inFinalTransformationsEnv(
     setArg(colon, 1, exprClass$new(name = 1, isLiteral = TRUE, isCall = FALSE,
                                    isName = FALSE, isAssign = FALSE))
     size_expr <- setArg(
-      colon, 2, nParse(paste0('cppLiteral("', vector_arg$name, '.size();")')))
+      colon, 2, nParse(paste0('cppLiteral("', vector_arg$name, '.size()")')))
     ## make the vector an argument of the reduce op and index it
     reduce_op <- code$args[[3]]
     setArg(reduce_op, 1, copyExprClass(vector_arg))

--- a/nCompiler/R/compile_generateCpp.R
+++ b/nCompiler/R/compile_generateCpp.R
@@ -209,7 +209,7 @@ inGenCppEnv(
 )
 
 inGenCppEnv(
-  MidOperator <- function(code, symTab) {
+    MidOperator <- function(code, symTab) {
     if(length(code$args) != 2) stop('Error: expecting 2 arguments for operator ',code$name)
     if(is.null(code$caller)) useParens <- FALSE
     else {

--- a/nCompiler/R/compile_labelAbstractTypes.R
+++ b/nCompiler/R/compile_labelAbstractTypes.R
@@ -763,12 +763,33 @@ inLabelAbstractTypesEnv(
 
 inLabelAbstractTypesEnv(
   ParallelReduce <- function(code, symTab, auxEnv, handlingInfo) {
-    if (length(code$args) != 3)
+    if(is.null(symTab$parentST))   #  TODO: this seems kludgey and perhaps should be done at a different processing stage.
+      stop(exprClassProcessingErrorMsg(
+        code,
+        paste0('In labelAbstractTypes handler ParallelReduce: ',
+               'parallel_reduce must be used in a method of an nClass, not in a stand-alone nFunction.')),
+        call. = FALSE)          
+    operatorDef <- operatorDefEnv[[code$args[[1]]$name]]
+    if (!is.null(operatorDef) && is.null(operatorDef$reduction))   # Check for validity only for our operators.
+    # TODO: perhaps this should just be a warning.        
+      stop(exprClassProcessingErrorMsg(
+        code,
+        paste0('In labelAbstractTypes handler ParallelReduce: ',
+               'function/operator `', code$args[[1]]$name, '` is not a valid reduction function/operator.')),
+        call. = FALSE)
+    if(length(code$args) == 2 && !is.null(operatorDef$reduction))
+      setArg(code, 3, nParse(operatorDef$reduction))
+    if (length(code$args) != 3) 
       stop(exprClassProcessingErrorMsg(
         code,
         paste('In labelAbstractTypes handler ParallelReduce:',
               'expected 3 arguments but got', length(code$args))),
         call. = FALSE)
+    if(code$args[[1]]$isName) {  ## Handle reduction function as function not char.        
+      code$args[[1]]$isName <- FALSE
+      code$args[[1]]$isLiteral <- TRUE
+      code$args[[1]]$Rexpr <- deparse(code$args[[1]]$Rexpr)
+    }
     ## process the initial value
     inserts <- compile_labelAbstractTypes(code$args[[3]], symTab, auxEnv)
     if (code$args[[3]]$type$nDim != 0)
@@ -778,12 +799,14 @@ inLabelAbstractTypesEnv(
               'initial value for parallel_reduce should be scalar but got',
               ' nDim = ', code$args[[3]]$type$nDim)),
         call. = FALSE)
-    if (isFALSE(code$args[[3]]$isLiteral))
-      stop(exprClassProcessingErrorMsg(
-        code,
-        paste('In labelAbstractTypes handler ParallelReduce:',
-              'initial value for parallel_reduce must be a literal')),
-        call. = FALSE)
+    if (isFALSE(code$args[[3]]$isLiteral)) {
+      if(!(code$args[[3]]$name == "-" && isTRUE(code$args[[3]]$args[[1]]$isLiteral)))  # Handle negative init.
+        stop(exprClassProcessingErrorMsg(
+          code,
+          paste('In labelAbstractTypes handler ParallelReduce:',
+                'initial value for parallel_reduce must be a literal value, not a variable or expression')),
+          call. = FALSE)
+    }
     ## process the reduce operator
     if (isTRUE(code$args[[1]]$isLiteral)) {
       if (!is.character(code$args[[1]]$name))
@@ -796,11 +819,11 @@ inLabelAbstractTypesEnv(
       code$args[[1]]$isLiteral <- FALSE
       code$args[[1]]$isCall <- TRUE
     }
-    ## give reduce operator the same return type as the initial value
+    ## give reduce operator the same return type as the input vector.
     ## TODO: Maybe symbolNF is the right type for the reduction op.
     code$args[[1]]$type <-
       symbolBasic$new(name = code$args[[1]]$name,
-                      nDim = 0, type = code$args[[3]]$type$type)
+                      nDim = 0, type = code$args[[2]]$type$type)
     ## finish by processing the vector arg
     inserts <- c(inserts, compile_labelAbstractTypes(code$args[[2]], symTab, auxEnv))
     if (code$args[[2]]$type$nDim != 1)
@@ -811,7 +834,7 @@ inLabelAbstractTypesEnv(
               code$args[[2]]$type$nDim)),
         call. = FALSE)
     code$type <- symbolBasic$new(name = code$name, nDim = 0,
-                                 type = code$args[[3]]$type$type)
+                                 type = code$args[[2]]$type$type)
     return(if (length(inserts) == 0) invisible(NULL) else inserts)
   }
 )

--- a/nCompiler/R/compile_normalizeCalls.R
+++ b/nCompiler/R/compile_normalizeCalls.R
@@ -1,3 +1,9 @@
+## Special cases placed here by analogy with `eigenizeUseArgs`,
+## but perhaps should be in handler list.
+normalizeCallsFunctionArgs <- list(
+    parallel_reduce = 1
+)
+
 normalizeCallsEnv <- new.env()
 normalizeCallsEnv$.debug <- FALSE
 
@@ -50,7 +56,10 @@ compile_normalizeCalls <- function(code,
     # What gets cached in the aux of the exprClass for the call:
     #   cachedOpInfo = list(opDef, name, obj_internals, case)
     #   We defer: uniqueName, cpp_code_name
-    cachedOpInfo <- update_cachedOpInfo(code, auxEnv$where)
+    fxnArg <- normalizeCallsFunctionArgs[[code$name]]
+    if(!is.null(fxnArg)) {  # Handle arguments that are functions (`parallel_reduce`).
+      cachedOpInfo <- update_cachedOpInfo(code$args[[fxnArg]], auxEnv$where)
+    } else cachedOpInfo <- update_cachedOpInfo(code, auxEnv$where)
     if(cachedOpInfo$case == "nFunction") {
       uniqueName <- cachedOpInfo$obj_internals$uniqueName2
       if(length(uniqueName)==0)
@@ -65,17 +74,19 @@ compile_normalizeCalls <- function(code,
         ## but we do not as a way to avoid having many references to R6 objects
         ## in a blind attempt to facilitate garbage collection based on past experience.
         ## Instead, we provide what is needed to look up the nFunction again later.
-        auxEnv$needed_nFunctions[[uniqueName]] <- list(code$name, auxEnv$where)
+        auxEnv$needed_nFunctions[[uniqueName]] <- list(code$args[[fxnArg]]$name, auxEnv$where)
       }
     }
 
-    opDef <- cachedOpInfo$opDef
-    matchDef <- opDef[["matchDef"]]
-    if(is.null(matchDef))
-      matchDef <- cachedOpInfo$obj_internals$default_matchDef
-    if(!is.null(matchDef)) {
-      exprClass_put_args_in_order(matchDef, code, opDef$compileArgs)
-      # code <- replaceArgInCaller(code, matched_code)
+    if(is.null(fxnArg)) {
+      opDef <- cachedOpInfo$opDef
+      matchDef <- opDef[["matchDef"]]
+      if(is.null(matchDef))
+        matchDef <- cachedOpInfo$obj_internals$default_matchDef
+      if(!is.null(matchDef)) {
+        exprClass_put_args_in_order(matchDef, code, opDef$compileArgs)
+        # code <- replaceArgInCaller(code, matched_code)
+      }
     }
     normalizeCallsEnv$recurse_normalizeCalls(code, symTab, auxEnv, handlingInfo)
   }

--- a/nCompiler/R/cppDefs_TBB.R
+++ b/nCompiler/R/cppDefs_TBB.R
@@ -1,4 +1,3 @@
-# not working
 ## cppDefs for parallel loop bodies for TBB
 
 cppParallelBodyClass <- R6::R6Class(
@@ -256,8 +255,9 @@ cppParallelReduceBodyClass_init_impl <- function(cppDef,
   vector_name <- orig_caller$args[[4]] ## should be a string
   initializerList <- list()
   initializerList[[1]] <- nParse(
-    substitute(X(X_), list(X = as.name(value_name),
-                           X_ = as.name(init_arg$name))))
+    substitute(X(X_), list(X = as.name(value_name))))
+  ## Need to directly parse the init value to handle various numeric cases, e.g., `Inf`.
+  setArg(initializerList[[1]], 1, init_arg) 
   initializerList[[2]] <- nParse(
     substitute(X(X_), list(X = as.name(vector_name),
                            X_ = as.name(paste0('parent.', vector_name)))))
@@ -278,14 +278,17 @@ cppParallelReduceBodyClass_init_impl <- function(cppDef,
                                             ref = TRUE,
                                             const = TRUE))
   ## make the reduce code
-  reduce_op <- exprClass$new(name = loop_body$args[[2]]$name, isCall = TRUE,
-                             isName = FALSE, isAssign = FALSE,
+  ## `aux` needed so that user-defined reduction functions will be replaced with `cpp_code_name`. 
+  reduce_op <- exprClass$new(name = loop_body$args[[2]]$name, aux = loop_body$args[[2]]$aux,
+                             isCall = TRUE, isName = FALSE, isAssign = FALSE,
                              isLiteral = FALSE)
   setArg(reduce_op, 1, copyExprClass(value_expr))
-  setArg(reduce_op, 2, nParse(paste0('cppLiteral("target.', value_name, ';")')))
+  setArg(reduce_op, 2, nParse(paste0('cppLiteral("target.', value_name, '")')))
   join_code <- newAssignmentExpression()
   setArg(join_code, 1, copyExprClass(value_expr))
   setArg(join_code, 2, reduce_op)
+  ## Put code in {} so handled by full processing later, in particular adding ending `;`.  
+  join_code <- newBracketExpr(list(join_code))  
   ## create the join cppFunctionClass definition
   join_body <- cppCodeBlockClass$new(code = join_code,
                                      ## TODO: any symbols ever needed?

--- a/nCompiler/R/cppDefs_nClass.R
+++ b/nCompiler/R/cppDefs_nClass.R
@@ -11,13 +11,13 @@ nClassBaseClass_init_impl <- function(cppDef) {
   cppDef$Hpreamble <- pluginIncludes
   cppDef$Hpreamble <- c(cppDef$Hpreamble,
                         "#define NCOMPILER_USES_EIGEN",
-                        "// #define NCOMPILER_USES_TBB",
+                        "#define NCOMPILER_USES_TBB",
                         "#define NCOMPILER_USES_NLIST",
                         "#define USES_NCOMPILER")
   cppDef$CPPpreamble <- pluginIncludes
   cppDef$CPPpreamble <- c(cppDef$CPPpreamble,
                         "#define NCOMPILER_USES_EIGEN",
-                        "// #define NCOMPILER_USES_TBB",
+                        "#define NCOMPILER_USES_TBB",
                         "#define NCOMPILER_USES_NLIST",
                         "#define USES_NCOMPILER")
 

--- a/nCompiler/R/cppDefs_nFunction.R
+++ b/nCompiler/R/cppDefs_nFunction.R
@@ -8,7 +8,7 @@ cpp_nFunctionClass_init_impl <- function(cppDef) {
   cppDef$Hpreamble <- pluginIncludes
   cppDef$Hpreamble <- c(cppDef$Hpreamble,
                         "#define NCOMPILER_USES_EIGEN",
-                        "// #define NCOMPILER_USES_TBB",
+                        "#define NCOMPILER_USES_TBB",
                         "#define NCOMPILER_USES_NLIST",
                         "#define USES_NCOMPILER")
   ## handler nList in labelAbstractTypes does record in auxEnv if an
@@ -19,7 +19,7 @@ cpp_nFunctionClass_init_impl <- function(cppDef) {
   cppDef$CPPpreamble <- pluginIncludes
   cppDef$CPPpreamble <- c(cppDef$CPPpreamble,
                           "#define NCOMPILER_USES_EIGEN",
-                          "// #define NCOMPILER_USES_TBB",
+                          "#define NCOMPILER_USES_TBB",
                           "#define NCOMPILER_USES_NLIST",
                           "#define USES_NCOMPILER")
   cppDef$Hincludes <- c(cppDef$Hincludes)#,

--- a/nCompiler/tests/testthat/tbb_tests/test-parallel_reduce.R
+++ b/nCompiler/tests/testthat/tbb_tests/test-parallel_reduce.R
@@ -1,0 +1,274 @@
+test_that("basic usage of parallel_reduce", {
+  nc <- nClass(
+    Cpublic = list(
+      go = nFunction(
+        fun = function(x = 'numericVector') {
+          y <- parallel_reduce('+', x)
+          return(y)
+        },
+        returnType = 'numericScalar'
+      )
+    )
+  )
+  Cnc <- nCompile(nc)
+  obj <- nc$new()
+  Cobj <- Cnc$new()
+  expect_identical(obj$go(101:110), as.numeric(sum(101:110)))
+  expect_identical(Cobj$go(101:110), as.numeric(sum(101:110)))
+
+  nc <- nClass(
+    Cpublic = list(
+      go = nFunction(
+        fun = function(x = 'numericVector') {
+          y <- parallel_reduce('+', x, 5)
+          return(y)
+        },
+        returnType = 'numericScalar'
+      )
+    )
+  )
+  Cnc <- nCompile(nc)
+  obj <- nc$new()
+  Cobj <- Cnc$new()
+  expect_identical(obj$go(101:110), as.numeric(5+sum(101:110)))
+  expect_identical(Cobj$go(101:110), as.numeric(5+sum(101:110)))
+
+  ## Negative values required some additional processing, so test that case explicitly.
+  nc <- nClass(
+    Cpublic = list(
+      go = nFunction(
+        fun = function(x = 'numericVector') {
+          y <- parallel_reduce('+', x, -5)
+          return(y)
+        },
+        returnType = 'numericScalar'
+      )
+    )
+  )
+  Cnc <- nCompile(nc)
+  obj <- nc$new()
+  Cobj <- Cnc$new()
+  expect_identical(obj$go(101:110), as.numeric(sum(101:110)-5))
+  expect_identical(Cobj$go(101:110), as.numeric(sum(101:110)-5))
+
+  nc <- nClass(
+    Cpublic = list(
+      go = nFunction(
+        fun = function(x = 'numericVector') {
+          y <- parallel_reduce('pairmin', x)
+          return(y)
+        },
+        returnType = 'numericScalar'
+      )
+    )
+  )
+  Cnc <- nCompile(nc)
+  obj <- nc$new()
+  Cobj <- Cnc$new()
+  x <- c(3.7, 2.5, 4.9, 3.1)
+  expect_identical(obj$go(x), 2.5)
+  expect_identical(Cobj$go(x), 2.5)
+
+  ## Operator as function (user-defined), not char.
+  mypairmin <- nFunction(
+      fun = function(x = 'numericScalar', y = 'numericScalar') {
+          return(pmin(x,y))
+      }, returnType = 'numericScalar'
+  )
+  
+  nc <- nClass(
+    Cpublic = list(
+      go = nFunction(
+        fun = function(x = 'numericVector') {
+          y <- parallel_reduce(mypairmin, x, Inf)
+          return(y)
+        },
+        returnType = 'numericScalar'
+      )
+    )
+  )
+  Cnc <- nCompile(nc, mypairmin)[[1]]
+  obj <- nc$new()
+  Cobj <- Cnc$new()
+  x <- c(3.7, 2.5, 4.9, 3.1)
+  expect_identical(obj$go(x), 2.5)
+  expect_identical(Cobj$go(x), 2.5)
+
+})
+
+test_that("error trapping for parallel_reduce", {
+  nc <- nClass(
+    Cpublic = list(
+      go = nFunction(
+        fun = function(x = 'numericVector') {
+          y <- parallel_reduce('-', x)
+          return(y)
+        },
+        returnType = 'numericScalar'
+      )
+    )
+  )
+  ## The error message is not silent. 
+  expect_error(Cnc <- nCompile(nc), "is not a valid reduction")  ## Compile-time error.
+  obj <- nc$new()
+  expect_error(obj$go(1:5), "not a valid reduction")  ## Run-time error.
+
+  ## No init for user-defined reduction function.
+  mypairmin <- nFunction(
+      fun = function(x = 'numericScalar', y = 'numericScalar') {
+          return(pmin(x,y))
+      }, returnType = 'numericScalar'
+  )
+  
+  nc <- nClass(
+    Cpublic = list(
+      go = nFunction(
+        fun = function(x = 'numericVector') {
+          y <- parallel_reduce(mypairmin, x)
+          return(y)
+        },
+        returnType = 'numericScalar'
+      )
+    )
+  )
+  expect_error(Cnc <- nCompile(nc, mypairmin)[[1]], "expected 3 arguments")
+  obj <- nc$new()
+  expect_error(obj$go(1:5), "no default value provided")
+
+
+  nc <- nClass(
+      Cpublic = list(
+          go = nFunction(
+              fun = function(x = 'numericVector', start = 'numericScalar') {
+                  y <- parallel_reduce('pairmin', x, start)
+                  return(y)
+              },
+              returnType = 'numericScalar'
+          )
+      )
+  )
+  expect_error(Cnc <- nCompile(nc), "must be a literal")
+
+  go = nFunction(
+      fun = function(x = 'numericVector') {
+          y <- parallel_reduce('+', x)
+          return(y)
+      },
+      returnType = 'numericScalar'
+  )
+  expect_error(Cgo <- nCompile(go), "must be used in a method of an nClass")
+
+})
+
+## Could add check for user-defined reduction function with defined default init via operatorDef.
+
+test_that("user-defined reduction functions", {
+    ## User-defined nFunction
+    reduction_fun <- nFunction(
+        fun = function(x = 'numericScalar', y = 'numericScalar') {
+            ans <- x + y
+            return(ans)
+        },
+        returnType = 'numericScalar'
+    )
+    
+    
+    nc <- nClass(
+        Cpublic = list(
+            go = nFunction(
+                fun = function(x = 'numericVector') {
+                    y <- parallel_reduce('reduction_fun', x, 0) 
+                    return(y)
+                },
+                returnType = 'numericScalar'
+            )
+        )
+    )
+    Cnc <- nCompile(nc, reduction_fun)[[1]]
+    obj <- nc$new()
+    Cobj <- Cnc$new()
+    expect_identical(obj$go(101:110), as.numeric(sum(101:110)))
+    expect_identical(Cobj$go(101:110), as.numeric(sum(101:110)))
+ 
+    ## See issue 133.
+    nc <- nClass(
+        Cpublic = list(
+            reduction_fun = nFunction(
+                fun = function(x = 'numericScalar', y = 'numericScalar') {
+                    ans <- x + y
+                    return(ans)
+                },
+                returnType = 'numericScalar'
+            ),
+            parallel_fun = nFunction(
+                fun = function(x = 'numericVector') {
+                    y <- parallel_reduce(reduction_fun, x, 0) 
+                    return(y)
+                },
+                returnType = 'numericScalar'
+            )
+        )
+    )
+    ## This particular error doesn't fit well with testthat for some reason.
+    ## expect_error(Cnc <- nCompile(nc))
+
+    nc0 <- nClass(
+        Cpublic = list(
+            reduction_fun = nFunction(
+                fun = function(x = 'numericScalar', y = 'numericScalar') {
+                    ans <- x + y
+                    return(ans)
+                },
+                returnType = 'numericScalar'
+            )
+        ))
+    
+    nc <- nClass(
+        Cpublic = list(
+            parallel_fun = nFunction(
+                fun = function(x = 'numericVector', obj = 'nc0') {
+                    y <- parallel_reduce(obj$reduction_fun, x, 0) 
+                    return(y)
+                },
+                returnType = 'numericScalar'
+            )
+        )
+    )
+    expect_error(result <- nCompile(nc, nc0), "not a valid reduction")
+    
+})
+
+
+test_that("reduction cases that don't work", {
+  nc <- nClass(
+    Cpublic = list(
+      go = nFunction(
+        fun = function(x = 'numericVector', y = 'numericVector') {
+          z <- parallel_reduce('+', x+y)
+          return(z)
+        },
+        returnType = 'numericScalar'
+      )
+    )
+  )
+  expect_error(Cnc <- nCompile(nc))
+  obj <- nc$new()
+  obj$go(1:5, 6:10)
+  expect_identical(obj$go(1:5, 6:10) , as.numeric(55))
+
+  nc <- nClass(
+    Cpublic = list(
+      go = nFunction(
+        fun = function(x = 'integerVector') {
+          z <- parallel_reduce('pairmin', x)
+          return(z)
+        },
+        returnType = 'integerScalar'
+      )
+    )
+  )
+  expect_error(Cnc <- nCompile(nc))  ## Lots of C++ compiler output.
+  
+})
+
+


### PR DESCRIPTION
This addresses various aspects of `parallel_reduce`, with a fair amount of testing. I generally tried to work within the system, but there may be cases where @perrydv may think we should do it differently or at a different stage. 

- This enables built-in reduction operators of +, *, pairmin, pairmax, with error trapping for use of other nCompiler operators.
- The init arg is now optional, and default values are built into the handler lists, via `reduction = <some_init>`. The existence of this is used for error trappling for valid reduction operators (perhaps this is trying to be too concise by combining the idea of a valid operator with the default init).
- The output type is determined from the type of the input vector (2nd arg). Perry's original code used the type of the init value. And Perry and Chris discussed generating dummy code: `reduction_op(x,y)` to determine type, but it seemed most natural to me to use the type of the vector. 
- User-defined reduction operators now work when provided as nFunctions (but not as other methods of the same class [see issue 133]). If no init is provided by the user we error trap. I have not tested having a user-defined operator in which the default init is provided.
- I've added some additional checking for uncompiled execution but there are problably corner cases.
- Inf and negative values for initial value now works.
- A user can provide the user-defined reduction function either as a char or as a function. In principle this would be fine for non-user-defined but there are no R pairmin/pairmax functions.
- Some work was needed to fix up C++ generation of the `join` for various situations.
- Use of parallel_reduce in a standalone nFunction is trapped, but in an awkward stage and awkward way.

The following are still issues:

 - Using a method of another class as the reduction operator does not work.
 - For min/max, one needs to use `pair{min,max}` as these are the actual relevant binary operators. We should discuss if we want to automatically convert {min,max} to these for the user.
 - Per issue #137 , using an expression as the input vector does not work.
 - Per issue #136  there are still some type issues when using integer types.
 - Should we rename to `parallelReduce` for consistency with other user-facing naming?