### PR TITLE
Robustify `nFunction` to handle 0-length `name` arg

### DIFF
--- a/nCompiler/R/NF.R
+++ b/nCompiler/R/NF.R
@@ -129,7 +129,7 @@ nFunction <- function(fun,
   # ADfun: should become AD_nFun
   ###
 
-  if(missing(name))
+  if(missing(name) || !length(name))   # Check for empty `name` per issue 162.
     name <- nFunctionLabelMaker()
   ## Create internals that will be used for compilation.
   internals <- NF_InternalsClass$new(fun,

--- a/nCompiler/tests/testthat/nimble_tests/test-compileNimble.R
+++ b/nCompiler/tests/testthat/nimble_tests/test-compileNimble.R
@@ -24,7 +24,7 @@ test_that("compileNimble bridge works for one nimbleFunction object", {
     run = function() {return(x[1]); returnType(double())}
   )
   nf1 <- nf()
-  Cnf1 <- compileNimble(nf1)
+  Cnf1 <- `:::`("nCompiler", "compileNimble")(nf1)
   expect_identical(Cnf1$x, 1:2)
 })
 ## NEXT STEPS:


### PR DESCRIPTION
Fixes issue #162 