### PR TITLE
allow type2symbol to find a type object in the expr of the type quosure

### DIFF
--- a/nCompiler/R/typeDeclarations.R
+++ b/nCompiler/R/typeDeclarations.R
@@ -513,6 +513,12 @@ type2symbol <- function(type,
   #   return(ans)
   # }
 
+  if(ttypeToUse |> rlang::get_expr() |> inherits("symbolBase")) {
+    ans <- ttypeToUse |> rlang::get_expr()
+    ans$name <- name
+    return(ans)
+  }
+
   typeSpec <- nTypeSpec(ttypeToUse)
   inputAsLiteral <- identical(rlang::quo_get_env(ttypeToUse), emptyenv())
   inputAsCharacter <- typeSpec$inputAsCharacter

--- a/nCompiler/tests/testthat/nimble_tests/test-compileNimble.R
+++ b/nCompiler/tests/testthat/nimble_tests/test-compileNimble.R
@@ -3,7 +3,7 @@
 ## The real tests will be running nimble's test suite.
 
 library(nimble)
-#library(nCompiler)
+library(nCompiler)
 library(testthat)
 
 test_that("compileNimble bridge works for simple nimbleFunction (RC function)",{
@@ -14,7 +14,7 @@ test_that("compileNimble bridge works for simple nimbleFunction (RC function)",{
       returnType(double())
     }
   )
-  CRCF1 <- `:::`("nCompiler", "compileNimble")(RCF1)
+  CRCF1 <- nCompiler:::compileNimble(RCF1)
   expect_equal(CRCF1(1:3), 6)
 })
 
@@ -24,7 +24,7 @@ test_that("compileNimble bridge works for one nimbleFunction object", {
     run = function() {return(x[1]); returnType(double())}
   )
   nf1 <- nf()
-  Cnf1 <- `:::`("nCompiler", "compileNimble")(nf1)
+  Cnf1 <- nCompiler:::compileNimble(nf1)
   expect_identical(Cnf1$x, 1:2)
 })
 ## NEXT STEPS:
@@ -33,3 +33,11 @@ test_that("compileNimble bridge works for one nimbleFunction object", {
 ## add nClass to nCompiler:::compileNimble
 ##
 ## document, document, document
+
+
+test <- nClass(
+  Cpublic = list(
+    x = nTypeBasic(name = "x", scalarType = "integer", nDim = 1)
+  )
+)
+ctest <- nCompile(test)

--- a/nCompiler/tests/testthat/tensorOps_tests/test-tensorOperations_reshaping.R
+++ b/nCompiler/tests/testthat/tensorOps_tests/test-tensorOperations_reshaping.R
@@ -158,12 +158,17 @@ test_that("tensorOperations with re-shaping for single ops", {
     expect_identical(opfun(V1, A3), op_v_a3(x = V1, y = A3))
 
     # nCompiler runtime errors on non-conformable inputs
+    cat("Next error message is expected:\n")
     expect_error(op_m_m(x = M1, y = M2))
+    cat("Next error message is expected:\n")
     expect_error(op_m_m(x = M1, y = M3))
+    cat("Next error message is expected:\n")
     expect_error(op_m_m(x = M1, y = M4))
 
     # nCompiler runtime errors where R would normally use recycling rule
+    cat("Next error message is expected:\n")
     expect_error(op_m_v(x = M3, y = V1))
+    cat("Next error message is expected:\n")
     expect_error(op_v_a3(x = V1, y = A4))
 
     # # Issues: These should throw errors, but don't. Are runtime args validated?


### PR DESCRIPTION
This small change allows a type to be a symbol object itself. For example, in a list of types for Cpublic members, a symbol could be injected directly, such as when a list is constructed and then included in Cpublic. This came up for supporting a "bridge" compiler for nimble.

This has passed tests except for one unrelated known failure that needs separate attention, so I am recording it as a PR and then will merge it.