### PR TITLE
Runtime dynamic access

### DIFF
--- a/nCompiler/R/Rexecution.R
+++ b/nCompiler/R/Rexecution.R
@@ -60,6 +60,7 @@ nAs <- function(object, type) {
   scalar_type <- storage.mode(object)
   input_dims <- dim(object) %||% length(object)
   output_dims <- make_nAs_output_dims(input_dims, output_nDim)
+  if(!length(output_dims)) output_dims <- 1
   value_dims <- dim(value) %||% length(value)
   if(!all.equal(output_dims, value_dims))
     stop("value doesn't conform to type in nAs<- assignment")

--- a/nCompiler/R/compile_generateCpp.R
+++ b/nCompiler/R/compile_generateCpp.R
@@ -617,18 +617,21 @@ inGenCppEnv(
   }
 )
 
-inGenCppEnv(
+nCompiler:::inGenCppEnv(
   As <- function(code, symTab) {
     obj_cpp  <- compile_generateCpp(code$args[[1]], symTab)
-    tgt_type <- code$type$type
-    tgt_nDim <- code$type$nDim
+    target_sym <- code$type
+#    tgt_type <- code$type$type
+#    tgt_nDim <- code$type$nDim
     use_stm  <- isTRUE(code$aux$useSTM)
     is_lhs   <- isTRUE(code$aux$onLHS)
 
-    tgt_cpp  <- as_op_scalarToCpp(tgt_type)
+    #tgt_cpp  <- as_op_scalarToCpp(target_sym$type)
     mode_arg <- if(is_lhs) ', AsMode::LHS' else if(use_stm) ', AsMode::STM' else ''
     # All proxy types expose operator()() — always append ().
-    paste0('as_nC<', tgt_cpp, ', ', tgt_nDim, mode_arg, '>(', obj_cpp, ')()')
+#    paste0('as_nC<', tgt_cpp, ', ', tgt_nDim, mode_arg, '>(', obj_cpp, ')()')
+    paste0('as_nC<', target_sym$genCppVar()$generate(""),
+            mode_arg, '>(', obj_cpp, ')()')
   }
 )
 

--- a/nCompiler/R/compile_labelAbstractTypes.R
+++ b/nCompiler/R/compile_labelAbstractTypes.R
@@ -329,7 +329,7 @@ inLabelAbstractTypesEnv(
 #   }
 # )
 
-inLabelAbstractTypesEnv(
+nCompiler:::inLabelAbstractTypesEnv(
   DoubleBracket <- function(code, symTab, auxEnv, handlingInfo) {
     # specializations from generic will have already been handled
     # e.g obj[[1]] where obj defines its own "[[" operator definition (opDef).
@@ -338,6 +338,26 @@ inLabelAbstractTypesEnv(
     useArgs[1] <- FALSE # already processed
     inserts <- recurse_labelAbstractTypes(code, symTab, auxEnv,
                                           handlingInfo, useArgs = useArgs)
+    if(inherits(code$args[[1]]$type, "symbolNC")) {
+      if(isTRUE(code$args[[2]]$isLiteral)) {
+        # This case is from the end of DollarSign (could be combined)
+        innerName <- as.character(code$args[[2]]$name)
+        symbol <- NCinternals(code$args[[1]]$type$NCgenerator)$symbolTable$getSymbol(innerName, inherits=TRUE)
+        if(is.null(symbol))
+          stop(exprClassProcessingErrorMsg(
+            code,
+            paste0('member variable ', innerName, ' of ', code$args[[1]]$name, ' could not be found.')
+          ), call. = FALSE)
+        code$type <- symbol$clone(deep = TRUE)
+        code$name <- '->member'
+      } else {
+        code$type <- symbolETaccBase$new(name = '')
+        code$name <- '->method'
+        insertArg(code, 2, exprClass$new(name = 'access', isName = TRUE, isCall = FALSE, 
+                                         isLiteral = FALSE, isAssign = FALSE))
+      }
+      return(if(length(inserts) == 0) NULL else inserts)
+    }
     # return type of x[[i]] is the element type of x
     # and return type of `[[<-`(x, i, value) is the type of value,
     #.  which is also the element type of x, so both cases have same return type

--- a/nCompiler/R/cppDefs_variables.R
+++ b/nCompiler/R/cppDefs_variables.R
@@ -195,6 +195,12 @@ cppNcppVec <- function(name = character(),
                       templateArgs = list(elementVar))
 }
 
+cppETaccBase <- function(name = character()) {
+  cppVarFullClass$new(name = name,
+                      baseType = "std::unique_ptr",
+                      templateArgs = list("ETaccessorBase"))
+}
+
 cppEigenTensorRef <- function(name = character(),
                               nDim,
                               scalarType) {

--- a/nCompiler/R/symbolTable.R
+++ b/nCompiler/R/symbolTable.R
@@ -442,39 +442,27 @@ symbolNcppVec <- R6::R6Class(
   )
 )
 
-
-## I think this was and old idea
-## symbolList <- R6::R6Class(
-##   classname = "symbolList",
-##   inherit = symbolBase,
-##   portable = TRUE,
-##   public = list(
-##     size = NULL,
-##     initialize = function(..., size = NA) {
-##       super$initialize(...)
-##       self$type = 'list'
-##       self$size <- size
-##       self
-##     },
-##     shortPrint = function() {
-##       'List'
-##     },
-##     print = function() {
-##       if(is.null(self$size)) {
-##         writeLines(
-##           paste0(self$name, ': ', self$type, ' size = (uninitialized),')
-##         )
-##       } else {
-##         writeLines(
-##           paste0(self$name, ': ', self$type, ' size = ', self$size)
-##         )
-##       }
-##     },
-##     genCppVar = function() {
-##       return(cppRcppList(name = self$name))
-##     }
-##   )
-## )
+symbolETaccBase <- R6::R6Class(
+  classname = "symbolETaccBase",
+  inherit = symbolBase,
+  portable = TRUE,
+  public = list(
+    initialize = function(name, isArg = FALSE) {
+      self$name <- name
+      self$type <- "ETaccessorBase"
+      self$isArg <- isArg
+    },
+    print = function() {
+      writeLines(paste0(self$name, ': symbolETaccBase (ETaccessorBase) '))
+    },
+    uniqueID = function(...) {
+      paste0("ETaccessorBase")
+    },
+    genCppVar = function() {
+      cppETaccBase(name = self$name)
+    }
+  )
+)
 
 symbolRcppType<- R6::R6Class(
   classname = "symbolRcppType",

--- a/nCompiler/inst/include/nCompiler/ET_Rcpp_ext/post_Rcpp/ETaccessor_post_Rcpp.h
+++ b/nCompiler/inst/include/nCompiler/ET_Rcpp_ext/post_Rcpp/ETaccessor_post_Rcpp.h
@@ -4,9 +4,34 @@
 #include <unsupported/Eigen/CXX11/Tensor>
 #include <type_traits>
 #include <nCompiler/ET_ext/StridedTensorMap.h>
+#include <nCompiler/ET_ext/post_Rcpp/tensorUtils.h>
+#include <nCompiler/ET_ext/post_Rcpp/tensorFlex.h>
 
 template<typename Scalar>
 class ETaccessorTyped;
+
+template<typename inDimsT, typename outDimsT>
+void set_output_dims(const inDimsT &inDim, outDimsT &outDim,
+                    size_t output_nDim) {
+  size_t in_nDim = inDim.size();
+  if(output_nDim >= in_nDim) {
+    for(size_t i = 0; i < in_nDim; ++i) 
+      outDim[i] = inDim[i];
+    for(size_t i = in_nDim; i < output_nDim; ++i)
+      outDim[i] = 1;
+  } else {
+    size_t i_out = 0;
+    for(size_t i_in = 0; i_in < in_nDim; ++i_in) {
+      if(inDim[i_in] > 1) {
+        if(i_out >= output_nDim)
+          Rcpp::stop("Too many non-singleton dimensions for requested morphing to lower dimensional object.");
+        outDim[i_out++] = inDim[i_in];
+      }
+    }
+    for(; i_out < output_nDim; ++i_out)
+      outDim[i_out] = 1;
+  }
+}
 
 enum class AsMode { TM, STM, LHS };
 
@@ -15,6 +40,7 @@ enum class AsMode { TM, STM, LHS };
 // template, instantiation is deferred to the call site where they are fully
 // defined.
 template<typename ViewType> class EmptyProxy;
+template<typename Scalar> class EmptyScalarProxy;
 template<typename TargetScalar, typename ViewType> class RHSCastProxy;
 template<typename TargetScalar, typename ViewType> class CastingProxy;
 
@@ -133,8 +159,11 @@ class ETaccessorTyped : public ETaccessorBase {
 
   // Central dispatch for as() operations. Returns a proxy wrapping the
   // appropriate view. All proxy types expose operator()() uniformly.
-  template<typename TargetScalar, int nDim, AsMode mode = AsMode::TM>
+  template<typename TargetType, AsMode mode = AsMode::TM, 
+           std::enable_if_t<std::is_same_v<type_category_t<TargetType>, eigenTensor>, int> = 0>
   auto asTyped() {
+    typedef typename Eigen::nDimTraits2<TargetType>::Scalar TargetScalar;
+    constexpr int nDim = Eigen::nDimTraits2<TargetType>::NumDimensions;
     if constexpr (std::is_same_v<TargetScalar, Scalar>) {
       if constexpr (mode == AsMode::TM)
         return EmptyProxy<ETM<nDim>>(mapTyped<nDim>());
@@ -156,6 +185,17 @@ class ETaccessorTyped : public ETaccessorBase {
     }
   }
 
+  template<typename TargetType, AsMode mode = AsMode::TM, 
+           std::enable_if_t<std::is_same_v<type_category_t<TargetType>, trueScalar>, int> = 0>
+  auto asTyped() {
+    typedef TargetType TargetScalar;
+    if constexpr (std::is_same_v<TargetScalar, Scalar>) {
+      return EmptyScalarProxy<TargetScalar>(scalarTyped());
+    } else {
+      return CastingScalarProxy<TargetScalar, Scalar>(scalarTyped());
+    }
+  }
+
   template<int output_nDim>
   ETM<output_nDim> mapTyped() {
     //innate_nDim is the nDim of the object.
@@ -166,32 +206,10 @@ class ETaccessorTyped : public ETaccessorBase {
     //but there both the LHS and RHS nDims are known at compile time.
     //Here only the output_nDim is known at compile time.
     //Also it looks like in checkAndSetupDims, RHS singletons are always dropped
-    typedef typename Eigen::internal::traits<ETM<output_nDim> >::Index Index;
+    // typedef typename Eigen::internal::traits<ETM<output_nDim> >::Index Index;
     typedef typename ETM<output_nDim>::Dimensions output_Dimensions;
     output_Dimensions outDim;
-    const auto intDims_ = this->intDims();
-    size_t innate_nDim = intDims_.size();
-    if(output_nDim >= innate_nDim) {
-      for(size_t i = 0; i < innate_nDim; ++i)
-        outDim[i] = intDims_[i];
-      if(output_nDim > innate_nDim) {
-        for(size_t i = innate_nDim; i < output_nDim; ++i)
-          outDim[i] = 1;
-      }
-    } else {
-      size_t i_out = 0;
-      for(size_t i_innate = 0 ; i_innate < innate_nDim; ++i_innate) {
-        if(intDims_[i_innate] > 1) {
-          if(i_out >= output_nDim) {
-            Rcpp::stop("Problem making a TensorMap from some form of access(): Too many non-singleton dimensions for the requested map dimensions.\n");
-            break;
-          } else {
-            outDim[i_out++] = intDims_[i_innate];
-          }
-        }
-      }
-      for( ; i_out < output_nDim; ++i_out ) outDim[i_out]=1;
-    }
+    set_output_dims(this->intDims(), outDim, output_nDim);
     return ETM<output_nDim>(data(), outDim);
   }
   ~ETaccessorTyped(){};
@@ -283,14 +301,6 @@ class ETaccessor<Eigen::Tensor<Scalar, nDim> > : public ETaccessorTyped<Scalar> 
     return wrap(obj);
   }
   ET &innerRef() {return obj;}
-  // Scalar &scalar() {
-  //   Dimensions dim = obj.dimensions();
-  //   for(int i = 0; i < nDim; ++i) {
-  //     if(dim[i]!=1)
-  //       Rcpp::stop("Invalid call to scalar() for ETaccessor with dimensions not all equal to 1.");
-  //   }
-  //   return *obj.data(); // would leak memory but will never be reached and may reduce compiler warnings
-  // }
   ET &obj;
   std::vector<int> intDims_;
 };
@@ -308,7 +318,6 @@ class ETaccessorScalar : public ETaccessorTyped<Scalar> {
     Rcpp::stop("Invalid call to ref() for ETaccessor to scalar.");
     return *new Eigen::Tensor<double, 0>(); // bad memory mgmt (would leak) but will never be called. only to show compiler valid return.
   }
-  //Scalar &scalar() {return obj;}
   Scalar &obj;
   std::vector<int> intDims_;
 };
@@ -319,14 +328,6 @@ class ETaccessor<double> : public ETaccessorScalar<double> {
   ETaccessor(double &obj_) : ETaccessorScalar(obj_) {};
   ~ETaccessor() {};
 };
-
-// // CppAD header is not read by here, so this needs attention.
-// template<>
-// class ETaccessor<CppAD::AD<double> > : public ETaccessorScalar<CppAD::AD<double> > {
-//   public:
-//   ETaccessor(CppAD::AD<double> &obj_) : ETaccessorScalar(obj_) {};
-//   ~ETaccessor() {};
-// };
 
 template<>
 class ETaccessor<int> : public ETaccessorScalar<int> {
@@ -342,44 +343,12 @@ class ETaccessor<bool> : public ETaccessorScalar<bool> {
   ~ETaccessor() {};
 };
 
-// template<>
-// class ETaccessor<double> : public ETaccessorTyped<double> {
-//   public:
-//   using Scalar = double;
-
-//   ETaccessor(Scalar &obj_) : obj(obj_) {};
-//   ~ETaccessor() {};
-//   Scalar *data() override {return &obj;}
-//   std::vector<int> &intDims() override {return intDims_;}
-//   void set(SEXP Sinput) override { obj = as<Scalar>(Sinput);}
-//   SEXP get() override {return wrap(obj);}
-//   Eigen::Tensor<double, 0> &ref() {
-//     Rcpp::stop("Invalid call to ref() for ETaccessor to scalar.");
-//     return *new Eigen::Tensor<double, 0>(); // bad memory mgmt (would leak) but will never be called. only to show compiler valid return.
-//   }
-//   Scalar &scalar() {return obj;}
-//   Scalar &obj;
-//   std::vector<int> intDims_;
-// };
-
 template<int nDim, typename Scalar>
 Eigen::Tensor<Scalar, nDim> &ETaccessorBase::ref() {
   auto castptr = dynamic_cast<ETaccessor<Eigen::Tensor<Scalar, nDim> >* >(this);
   if(castptr == nullptr) Rcpp::stop("Problem creating a ref() from some form of access().\n");
   return castptr->innerRef();
 }
-
-// template<typename Scalar>
-// Scalar &ETaccessorBase::scalar() {
-//   auto castptr = dynamic_cast<ETaccessor<Scalar>* >(this);
-//   if(castptr == nullptr) Rcpp::stop("Problem creating a scalar() from some form of access().\n");
-//   return castptr->scalar();
-// }
-
-// template<typename Scalar, int nDim>
-// auto access(Eigen::Tensor<Scalar, nDim> &x) -> ETaccessor<Eigen::Tensor<Scalar, nDim> >{
-//   return ETaccessor<Eigen::Tensor<Scalar, nDim> >(x);
-// }
 
 template<typename T>
 auto ETaccess(T &x) -> ETaccessor<T>{

--- a/nCompiler/inst/include/nCompiler/ET_Rcpp_ext/post_Rcpp/ETaccessor_post_Rcpp.h
+++ b/nCompiler/inst/include/nCompiler/ET_Rcpp_ext/post_Rcpp/ETaccessor_post_Rcpp.h
@@ -43,6 +43,7 @@ template<typename ViewType> class EmptyProxy;
 template<typename Scalar> class EmptyScalarProxy;
 template<typename TargetScalar, typename ViewType> class RHSCastProxy;
 template<typename TargetScalar, typename ViewType> class CastingProxy;
+template<typename TargetScalar, typename Scalar> class CastingScalarProxy;
 
 // Virtual nDim-general methods (e.g. resize, conversions to and from SEXP).
 class ETaccessorBase {

--- a/nCompiler/inst/include/nCompiler/ET_Rcpp_ext/post_Rcpp/nC_as.h
+++ b/nCompiler/inst/include/nCompiler/ET_Rcpp_ext/post_Rcpp/nC_as.h
@@ -34,6 +34,30 @@ public:
   ViewType& operator()() { return view_; }
 };
 
+template<typename Scalar>
+class EmptyScalarProxy {
+  Scalar& scalar_;
+public:
+  explicit EmptyScalarProxy(Scalar& s) : scalar_(s) {}
+  EmptyScalarProxy(const EmptyScalarProxy&) = delete;
+  EmptyScalarProxy& operator=(const EmptyScalarProxy&) = delete;
+  Scalar& operator()() { return scalar_; }
+};
+
+template<typename TargetScalar,typename Scalar>
+class CastingScalarProxy {
+  Scalar& scalar_;
+  TargetScalar casted_scalar_;
+public:
+  explicit CastingScalarProxy(Scalar& s) : scalar_(s), casted_scalar_(static_cast<TargetScalar>(s)) {}
+  CastingScalarProxy(const CastingScalarProxy&) = delete;
+  CastingScalarProxy& operator=(const CastingScalarProxy&) = delete;
+  TargetScalar& operator()() { return casted_scalar_; }
+  ~CastingScalarProxy() {
+    scalar_ = static_cast<Scalar>(casted_scalar_);
+  }
+};
+
 // RHSCastProxy<TargetScalar, ViewType>
 //
 // Cross-scalar RHS proxy. ViewType is TM (AsMode::TM, non-indexed) or STM
@@ -104,8 +128,68 @@ public:
 //   as_nC<int,1>(*acc)()(i)                         // element read
 //   as_nC<int,1,AsMode::LHS>(*acc)()(i) = val;      // element write
 //   as_nC<int,1,AsMode::LHS>(*acc)() = rhs;         // whole-object write
-template<typename TargetScalar, int nDim>
+
+template<typename TargetType>
 class RuntimeCastingProxy {
+  // TargetType5o here should be a true scalar type,
+  // because specialization to Eigen::Tensor types is below.
+  typedef TargetType TargetScalar;
+
+  ETaccessorBase& source_;
+  bool is_lhs_;
+  bool copy_made_;
+  TargetScalar copy_;
+  TargetScalar* data_ptr_;
+
+  void castCopyFrom() {
+    if constexpr (std::is_same_v<TargetScalar, double>)
+      source_.castCopyToDouble(&copy_, 1);
+    else if constexpr (std::is_same_v<TargetScalar, int>)
+      source_.castCopyToInt(&copy_, 1);
+    else if constexpr (std::is_same_v<TargetScalar, bool>)
+      source_.castCopyToBool(&copy_, 1);
+    else
+      Rcpp::stop("RuntimeCastingProxy: unsupported TargetScalar type.");
+    data_ptr_ = &copy_;
+    copy_made_ = true;
+  }
+
+  void writeBack() {
+    if constexpr (std::is_same_v<TargetScalar, double>)
+      source_.writeBackFromDouble(&copy_, 1);
+    else if constexpr (std::is_same_v<TargetScalar, int>)
+      source_.writeBackFromInt(&copy_, 1);
+    else if constexpr (std::is_same_v<TargetScalar, bool>)
+      source_.writeBackFromBool(&copy_, 1);
+    else
+      Rcpp::stop("RuntimeCastingProxy: unsupported TargetScalar type.");
+  }
+
+public:
+  explicit RuntimeCastingProxy(ETaccessorBase& acc, bool is_lhs = false)
+    : source_(acc), is_lhs_(is_lhs), copy_made_(false)
+  {
+    auto* typed = dynamic_cast<ETaccessorTyped<TargetScalar>*>(&acc);
+    if(typed) {
+      // Same scalar type: view directly, no copy.
+      data_ptr_ = &acc.scalar<TargetScalar>();
+    } else {
+      castCopyFrom();
+    }
+  }
+  
+  ~RuntimeCastingProxy() {
+    if(copy_made_ && is_lhs_) writeBack();
+  }
+
+  RuntimeCastingProxy(const RuntimeCastingProxy&) = delete;
+  RuntimeCastingProxy& operator=(const RuntimeCastingProxy&) = delete;
+
+  TargetScalar& operator()() { return *data_ptr_; }
+};
+
+template<typename TargetScalar, int nDim>
+class RuntimeCastingProxy<Eigen::Tensor<TargetScalar, nDim> > {
   using TM = Eigen::TensorMap<Eigen::Tensor<TargetScalar, nDim>>;
   using CopyTensor = Eigen::Tensor<TargetScalar, nDim>;
 
@@ -118,21 +202,7 @@ class RuntimeCastingProxy {
   // Mirrors mapTyped singleton-drop/pad logic from ETaccessorTyped.
   Eigen::array<Eigen::Index, nDim> computeDims(const std::vector<int>& intDims) {
     Eigen::array<Eigen::Index, nDim> outDim;
-    int innate_nDim = static_cast<int>(intDims.size());
-    if(nDim >= innate_nDim) {
-      for(int i = 0; i < innate_nDim; ++i) outDim[i] = intDims[i];
-      for(int i = innate_nDim; i < nDim; ++i) outDim[i] = 1;
-    } else {
-      int i_out = 0;
-      for(int i_in = 0; i_in < innate_nDim; ++i_in) {
-        if(intDims[i_in] > 1) {
-          if(i_out >= nDim)
-            Rcpp::stop("RuntimeCastingProxy: too many non-singleton dimensions for requested nDim.");
-          outDim[i_out++] = intDims[i_in];
-        }
-      }
-      for(; i_out < nDim; ++i_out) outDim[i_out] = 1;
-    }
+    set_output_dims(intDims, outDim, nDim);
     return outDim;
   }
 
@@ -203,16 +273,24 @@ public:
 
 // Compile-time source: delegates to ETaccessorTyped<Scalar>::asTyped<>().
 // Returns EmptyProxy<TM>, EmptyProxy<STM>, RHSCastProxy, or CastingProxy.
-template<typename TargetScalar, int nDim, AsMode mode = AsMode::TM, typename T>
+template<typename TargetType, AsMode mode = AsMode::TM, typename T>
 auto as_nC(T& x) {
-  return ETaccess(x).template asTyped<TargetScalar, nDim, mode>();
+  return ETaccess(x).template asTyped<TargetType, mode>();
 }
 
 // Runtime source: scalar type of acc is unknown at compile time.
 // Returns RuntimeCastingProxy. Write-back occurs on destruction iff mode == LHS.
-template<typename TargetScalar, int nDim, AsMode mode = AsMode::TM>
-RuntimeCastingProxy<TargetScalar, nDim> as_nC(ETaccessorBase& acc) {
-  return RuntimeCastingProxy<TargetScalar, nDim>(acc, mode == AsMode::LHS);
+template<typename TargetType, AsMode mode = AsMode::TM>
+RuntimeCastingProxy<TargetType> as_nC(ETaccessorBase& acc) {
+  return RuntimeCastingProxy<TargetType>(acc, mode == AsMode::LHS);
+}
+
+// genericInterfaceBaseC::access() returns a unique_ptr<ETaccessorBase>,
+// so this overload allows direct passing of the unique_ptr, for simpler usage and code-generation.
+// This takes its argument by value, so that it can be an rvalue (returned from another call at the call site).
+template<typename TargetType, AsMode mode = AsMode::TM>
+RuntimeCastingProxy<TargetType> as_nC(std::unique_ptr<ETaccessorBase> acc) {
+    return RuntimeCastingProxy<TargetType>(*acc, mode == AsMode::LHS);
 }
 
 #endif // NCOMPILER_NC_AS_H_

--- a/nCompiler/inst/include/nCompiler/ET_Rcpp_ext/post_Rcpp/nC_as.h
+++ b/nCompiler/inst/include/nCompiler/ET_Rcpp_ext/post_Rcpp/nC_as.h
@@ -289,7 +289,13 @@ RuntimeCastingProxy<TargetType> as_nC(ETaccessorBase& acc) {
 // so this overload allows direct passing of the unique_ptr, for simpler usage and code-generation.
 // This takes its argument by value, so that it can be an rvalue (returned from another call at the call site).
 template<typename TargetType, AsMode mode = AsMode::TM>
-RuntimeCastingProxy<TargetType> as_nC(std::unique_ptr<ETaccessorBase> acc) {
+RuntimeCastingProxy<TargetType> as_nC(std::unique_ptr<ETaccessorBase>& acc) {
+    return RuntimeCastingProxy<TargetType>(*acc, mode == AsMode::LHS);
+}
+
+
+template<typename TargetType, AsMode mode = AsMode::TM>
+RuntimeCastingProxy<TargetType> as_nC(std::unique_ptr<ETaccessorBase>&& acc) {
     return RuntimeCastingProxy<TargetType>(*acc, mode == AsMode::LHS);
 }
 

--- a/nCompiler/inst/include/nCompiler/ET_ext/post_Rcpp/tensorFlex.h
+++ b/nCompiler/inst/include/nCompiler/ET_ext/post_Rcpp/tensorFlex.h
@@ -57,6 +57,10 @@ struct eigenTensor {};
     typedef trueScalar type;
   };
   
+// This was added much later than initial development of this file,
+// so it is has not been propagated into use.
+template <typename T>
+using type_category_t = typename type_category<T>::type;
 
 // checkDimsAllOne returns true if all dimensions are 1s, false otherwise
 template<int Ndim>

--- a/nCompiler/inst/include/nCompiler/ET_ext/post_Rcpp/tensorUtils.h
+++ b/nCompiler/inst/include/nCompiler/ET_ext/post_Rcpp/tensorUtils.h
@@ -45,6 +45,8 @@ namespace Eigen {
     typedef nDimTraitsInternal2<const XprType, DefaultDevice> Internal;
     typedef typename nDimTraitsInternal2<const XprType, DefaultDevice>::Dimensions Dimensions;
     static const std::size_t NumDimensions = internal::traits<XprType>::NumDimensions;
+    typedef typename Eigen::internal::traits<XprType>::Scalar Scalar;
+
 
     EIGEN_DEVICE_FUNC nDimTraits2(const XprType& xpr) :
       m_Internal(xpr, Eigen::DefaultDevice())
@@ -67,18 +69,22 @@ namespace Eigen {
   template<>
   struct nDimTraits2<double> {
     static const std::size_t NumDimensions = 0;
+    typedef double Scalar;
   };
   template<>
   struct nDimTraits2<long> {
     static const  std::size_t NumDimensions = 0;
+    typedef long Scalar;
   };
   template<>
   struct nDimTraits2<int> {
     static const  std::size_t NumDimensions = 0;
+    typedef int Scalar;
   };
   template<>
   struct nDimTraits2<bool> {
     static const  std::size_t NumDimensions = 0;
+    typedef bool Scalar;
   };
 
 // This is used in one place, generated code for Rep.

--- a/nCompiler/tests/testthat/specificOp_tests/test-ETaccess-DSL.R
+++ b/nCompiler/tests/testthat/specificOp_tests/test-ETaccess-DSL.R
@@ -75,26 +75,29 @@ test_that("as(obj[[var_name]], type) works", {
       x = 'numericVector'
     )
   )
-  nf <- nFunction(
-    function(obj = 'nc', var_name = 'string') {
-      v <- as(obj[[var_name]], 'numericVector')
-        return(v)
-      returnType('numericVector')
-    }
+  nc2 <- nClass(
+    Cpublic = list(
+      nf = nFunction(
+        function(obj = 'nc', var_name = 'string') {
+          v <- as(obj[[var_name]], 'numericVector')
+          return(v)
+          returnType('numericVector')
+        }
+      )
+    )
   )
   for(mode in c("R","non-pkg", "pkg")) {
     if(mode == "R") {
       obj <- nc$new()
-      foo <- nf
+      obj2 <- nc2$new()
     } else {
       package <- mode=="pkg"
-      comp <- nCompile(nc, nf, package = package)
+      comp <- nCompile(nc, nc2, package = package)
       obj <- comp$nc$new()
-      foo <- comp$nf
+      obj2 <- comp$nc2$new()
     }
     obj$x <- c(1.2, 2.3)
-    foo(obj, "x")
-    expect_equal(foo(obj, "x"), obj$x)
+    expect_equal(obj2$nf(obj, "x"), obj$x)
     rm(obj); gc()
   }
 })

--- a/nCompiler/tests/testthat/specificOp_tests/test-ETaccess-DSL.R
+++ b/nCompiler/tests/testthat/specificOp_tests/test-ETaccess-DSL.R
@@ -7,25 +7,29 @@ test_that("obj[['x']] works like obj$x", {
       x = 'numericVector'
     )
   )
-  nf <- nFunction(
-    function(obj = 'nc') {
-      v <- obj[["x"]]
-      return(v)
-      returnType('numericVector')
-    }
+  nc2 <- nClass(
+    Cpublic = list(
+      nf = nFunction(
+        function(obj = 'nc') {
+          v <- obj[["x"]]
+          return(v)
+          returnType('numericVector')
+        }
+      )
+    )
   )
   for(mode in c("R","non-pkg", "pkg")) {
     if(mode == "R") {
       obj <- nc$new()
-      foo <- nf
+      obj2 <- nc2$new()
     } else {
       package <- mode=="pkg"
-      comp <- nCompile(nc, nf, package = package)
+      comp <- nCompile(nc, nc2, package = package)
       obj <- comp$nc$new()
-      foo <- comp$nf
+      obj2 <- comp$nc2$new()
     }
     obj$x <- c(1.2, 2.3)
-    expect_equal(foo(obj), obj$x)
+    expect_equal(obj2$nf(obj), obj$x)
     rm(obj); gc()
   }
 })
@@ -37,27 +41,30 @@ test_that("obj[[var_name]] works", {
       x = 'numericVector'
     )
   )
-  nf <- nFunction(
-    function(obj = 'nc', var_name = 'string') {
-      ETacc <- obj[[var_name]]
-      v <- as(ETacc, 'numericVector')
-      return(v)
-      returnType('numericVector')
-    }
+  nc2 <- nClass(
+    Cpublic = list(
+      nf = nFunction(
+        function(obj = 'nc', var_name = 'string') {
+          ETacc <- obj[[var_name]]
+          v <- as(ETacc, 'numericVector')
+          return(v)
+          returnType('numericVector')
+        }
+      )
+    )
   )
   for(mode in c("R","non-pkg", "pkg")) {
     if(mode == "R") {
       obj <- nc$new()
-      foo <- nf
+      obj2 <- nc2$new()
     } else {
       package <- mode=="pkg"
-      comp <- nCompile(nc, nf, package = package)
+      comp <- nCompile(nc, nc2, package = package)
       obj <- comp$nc$new()
-      foo <- comp$nf
+      obj2 <- comp$nc2$new()
     }
     obj$x <- c(1.2, 2.3)
-    foo(obj, "x")
-    expect_equal(foo(obj, "x"), obj$x)
+    expect_equal(obj2$nf(obj, "x"), obj$x)
     rm(obj); gc()
   }
 })

--- a/nCompiler/tests/testthat/specificOp_tests/test-ETaccess-DSL.R
+++ b/nCompiler/tests/testthat/specificOp_tests/test-ETaccess-DSL.R
@@ -1,0 +1,93 @@
+library(nCompiler)
+library(testthat)
+
+test_that("obj[['x']] works like obj$x", {
+  nc <- nClass(
+    Cpublic = list(
+      x = 'numericVector'
+    )
+  )
+  nf <- nFunction(
+    function(obj = 'nc') {
+      v <- obj[["x"]]
+      return(v)
+      returnType('numericVector')
+    }
+  )
+  for(mode in c("R","non-pkg", "pkg")) {
+    if(mode == "R") {
+      obj <- nc$new()
+      foo <- nf
+    } else {
+      package <- mode=="pkg"
+      comp <- nCompile(nc, nf, package = package)
+      obj <- comp$nc$new()
+      foo <- comp$nf
+    }
+    obj$x <- c(1.2, 2.3)
+    expect_equal(foo(obj), obj$x)
+    rm(obj); gc()
+  }
+})
+
+
+test_that("obj[[var_name]] works", {
+  nc <- nClass(
+    Cpublic = list(
+      x = 'numericVector'
+    )
+  )
+  nf <- nFunction(
+    function(obj = 'nc', var_name = 'string') {
+      ETacc <- obj[[var_name]]
+      v <- as(ETacc, 'numericVector')
+      return(v)
+      returnType('numericVector')
+    }
+  )
+  for(mode in c("R","non-pkg", "pkg")) {
+    if(mode == "R") {
+      obj <- nc$new()
+      foo <- nf
+    } else {
+      package <- mode=="pkg"
+      comp <- nCompile(nc, nf, package = package)
+      obj <- comp$nc$new()
+      foo <- comp$nf
+    }
+    obj$x <- c(1.2, 2.3)
+    foo(obj, "x")
+    expect_equal(foo(obj, "x"), obj$x)
+    rm(obj); gc()
+  }
+})
+
+test_that("as(obj[[var_name]], type) works", {
+  nc <- nClass(
+    Cpublic = list(
+      x = 'numericVector'
+    )
+  )
+  nf <- nFunction(
+    function(obj = 'nc', var_name = 'string') {
+      v <- as(obj[[var_name]], 'numericVector')
+        return(v)
+      returnType('numericVector')
+    }
+  )
+  for(mode in c("R","non-pkg", "pkg")) {
+    if(mode == "R") {
+      obj <- nc$new()
+      foo <- nf
+    } else {
+      package <- mode=="pkg"
+      comp <- nCompile(nc, nf, package = package)
+      obj <- comp$nc$new()
+      foo <- comp$nf
+    }
+    obj$x <- c(1.2, 2.3)
+    foo(obj, "x")
+    expect_equal(foo(obj, "x"), obj$x)
+    rm(obj); gc()
+  }
+})

--- a/nCompiler/tests/testthat/specificOp_tests/test-as.R
+++ b/nCompiler/tests/testthat/specificOp_tests/test-as.R
@@ -823,7 +823,7 @@ test_that("as(): ETaccessorBase RHS paths (same-scalar, cross-scalar sum and ele
           data <- ncAcc$new()
           data$x <- v
           ans <- 0.0
-          cppLiteral('{ auto _acc = data->access("x"); flex_(ans) = as_nC<double,1>(*_acc)().sum(); }')
+          cppLiteral('{ auto _acc = data->access("x"); flex_(ans) = as_nC<Eigen::Tensor<double,1> >(*_acc)().sum(); }')
           return(ans)
           returnType(numericScalar)
         }
@@ -834,7 +834,7 @@ test_that("as(): ETaccessorBase RHS paths (same-scalar, cross-scalar sum and ele
           data <- ncAcc$new()
           data$x <- v
           ans <- 0L
-          cppLiteral('{ auto _acc = data->access("x"); flex_(ans) = as_nC<int,1>(*_acc)().sum(); }')
+          cppLiteral('{ auto _acc = data->access("x"); flex_(ans) = as_nC<Eigen::Tensor<int,1> >(*_acc)().sum(); }')
           return(ans)
           returnType(integerScalar)
         }
@@ -845,7 +845,7 @@ test_that("as(): ETaccessorBase RHS paths (same-scalar, cross-scalar sum and ele
           data <- ncAcc$new()
           data$x <- v
           ans <- 0L
-          cppLiteral('{ auto _acc = data->access("x"); flex_(ans) = as_nC<int,1>(*_acc)()(i - 1); }')
+          cppLiteral('{ auto _acc = data->access("x"); flex_(ans) = as_nC<Eigen::Tensor<int,1> >(*_acc)()(i - 1); }')
           return(ans)
           returnType(integerScalar)
         }
@@ -881,9 +881,9 @@ test_that("as(): ETaccessorBase LHS paths (same-scalar write-through, cross-scal
         function(v = numericVector) {
           data <- ncAcc$new()
           data$x <- numeric(length = length(v), value = 0)
-          cppLiteral('{ auto _acc = data->access("x"); as_nC<double,1,AsMode::LHS>(*_acc)() = v; }')
+          cppLiteral('{ auto _acc = data->access("x"); as_nC<Eigen::Tensor<double,1> ,AsMode::LHS>(*_acc)() = v; }')
           ans <- 0.0
-          cppLiteral('{ auto _acc2 = data->access("x"); flex_(ans) = as_nC<double,1>(*_acc2)().sum(); }')
+          cppLiteral('{ auto _acc2 = data->access("x"); flex_(ans) = as_nC<Eigen::Tensor<double,1> >(*_acc2)().sum(); }')
           return(ans)
           returnType(numericScalar)
         }
@@ -893,9 +893,9 @@ test_that("as(): ETaccessorBase LHS paths (same-scalar write-through, cross-scal
         function(v = integerVector) {
           data <- ncAcc$new()
           data$x <- numeric(length = length(v), value = 0)
-          cppLiteral('{ auto _acc = data->access("x"); as_nC<int,1,AsMode::LHS>(*_acc)() = v; }')
+          cppLiteral('{ auto _acc = data->access("x"); as_nC<Eigen::Tensor<int,1>,AsMode::LHS>(*_acc)() = v; }')
           ans <- 0.0
-          cppLiteral('{ auto _acc2 = data->access("x"); flex_(ans) = as_nC<double,1>(*_acc2)().sum(); }')
+          cppLiteral('{ auto _acc2 = data->access("x"); flex_(ans) = as_nC<Eigen::Tensor<double,1> >(*_acc2)().sum(); }')
           return(ans)
           returnType(numericScalar)
         }

--- a/nCompiler/tests/testthat/specificOp_tests/test-as.R
+++ b/nCompiler/tests/testthat/specificOp_tests/test-as.R
@@ -37,6 +37,7 @@ test_that("as(): same scalar 2D→1D singleton-drop, RHS", {
       )
     )
   )
+  package <- FALSE
   for(mode in c("R", "non_pkg", "pkg")) {
     if(mode == "R") {
       nco <- nc$new()
@@ -622,6 +623,178 @@ test_that("as(): LHS range assignment cross-scalar (double source, integer view)
     expect_equal(result, c(10.0, 20.0, 30.0, 4.0, 5.0))
     rm(nco); gc()
   }
+})
+
+# Inputs are true scalars, target type is non-scalar
+# same scalar element type
+test_that("as(): true scalar input (same element type)", {
+  foo <- nFunction(
+    function(x = 'numericScalar', scalar_res = numericVector()) {
+      v <- as(x, 'numericMatrix')
+      y <- x
+      w <- v
+      as(y, "numericMatrix") <- 3*w
+      scalar_res[1] <- y
+      return(v)
+      returnType(double(2))
+    },
+    refArgs = "scalar_res"
+  )
+  cfoo <- nCompile(foo)
+  scalar_res <- 0
+  ans <- foo(2, scalar_res)
+  cscalar_res <- -1
+  cans <- cfoo(2, cscalar_res)
+  expect_identical(ans, cans)
+  expect_identical(dim(cans), c(1L,1L))
+  expect_equal(cans[1,1], 2)
+
+  expect_identical(scalar_res, cscalar_res)
+  expect_identical(cscalar_res, 6)
+  rm(ans, cans); gc()
+})
+
+# cross scalar element type
+test_that("as(): true scalar input (different element type)", {
+  foo <- nFunction(
+    function(x = 'numericScalar', scalar_res = numericVector()) {
+      v <- as(x, 'integerMatrix')
+      y <- x
+      w <- v
+      as(y, "integerMatrix") <- 3*w
+      scalar_res[1] <- y
+      return(v)
+      returnType(integer(2))
+    },
+    refArgs = "scalar_res"
+  )
+  cfoo <- nCompile(foo)
+  scalar_res <- 0
+  ans <- foo(2, scalar_res)
+  cscalar_res <- -1
+  cans <- cfoo(2, cscalar_res)
+  expect_identical(ans, cans)
+  expect_identical(dim(cans), c(1L,1L))
+  expect_identical(cans[1,1], 2L)
+
+  expect_identical(scalar_res, cscalar_res)
+  expect_identical(cscalar_res, 6)
+  rm(ans, cans); gc()
+})
+
+
+# Inputs are NOT true scalars, target type is true scalar
+# same type
+test_that("as(): true scalar target type (same element type)", {
+  foo <- nFunction(
+    function(x = 'numericMatrix', scalar_res = numericVector()) {
+      v <- as(x, 'numericScalar')
+      y <- x
+      w <- v
+      as(y, "numericScalar") <- 3*w
+      scalar_res[1] <- y[1,1]
+      return(v)
+      returnType(double())
+    },
+    refArgs = "scalar_res"
+  )
+  cfoo <- nCompile(foo)
+  x <- matrix(2, nrow = 1, ncol = 1)
+  scalar_res <- 0
+  ans <- foo(x, scalar_res)
+  cscalar_res <- -1
+  cans <- cfoo(x, cscalar_res)
+  expect_identical(ans, cans)
+  expect_true(is.null(dim(cans)))
+  expect_equal(cans, 2)
+  expect_identical(scalar_res, cscalar_res)
+  expect_identical(cscalar_res, 6)
+  rm(ans, cans); gc()
+})
+
+# cross type
+test_that("as(): true scalar target type (same element type)", {
+  foo <- nFunction(
+    function(x = 'integerMatrix', scalar_res = numericVector()) {
+      v <- as(x, 'numericScalar')
+      y <- x
+      w <- v
+      as(y, "numericScalar") <- 3*w
+      scalar_res[1] <- y[1,1]
+      return(v)
+      returnType(double())
+    },
+    refArgs = "scalar_res"
+  )
+  cfoo <- nCompile(foo)
+  x <- matrix(2, nrow = 1, ncol = 1)
+  scalar_res <- 0
+  ans <- foo(x, scalar_res)
+  cscalar_res <- -1
+  cans <- cfoo(x, cscalar_res)
+  expect_identical(ans, cans)
+  expect_true(is.null(dim(cans)))
+  expect_equal(cans, 2)
+  expect_identical(scalar_res, cscalar_res)
+  expect_identical(cscalar_res, 6)
+  rm(ans, cans); gc()
+})
+
+# Inputs are true scalars and output is also a true scalar
+# same type
+test_that("as(): true scalar input and  target type (same element type)", {
+  foo <- nFunction(
+    function(x = 'numericScalar', scalar_res = numericVector()) {
+      v <- as(x, 'numericScalar')
+      y <- x
+      w <- v
+      as(y, "numericScalar") <- 3*w
+      scalar_res[1] <- y
+      return(v)
+      returnType(double())
+    },
+    refArgs = "scalar_res"
+  )
+  cfoo <- nCompile(foo)
+  x <- 2.3
+  scalar_res <- 1
+  ans <- foo(x, scalar_res)
+  cscalar_res <- 0
+  cans <- cfoo(x, cscalar_res)
+  expect_identical(ans, cans)
+  expect_true(is.null(dim(cans)))
+  expect_equal(cans, 2.3)
+  expect_identical(scalar_res, cscalar_res)
+  expect_identical(cscalar_res, 3*2.3)
+  rm(ans, cans); gc()
+})
+
+# cross type
+test_that("as(): true scalar input and  target type (different element type)", {
+  foo <- nFunction(
+    function(x = 'numericScalar', scalar_res = numericVector()) {
+      v <- as(x, 'integerScalar')
+      y <- x
+      w <- v
+      as(y, "integerScalar") <- 3*w
+      scalar_res[1] <- y
+      return(v)
+      returnType(integer())
+    },
+    refArgs = "scalar_res"
+  )
+  cfoo <- nCompile(foo)
+  x <- 2.3
+  scalar_res <- 1
+  ans <- foo(x, scalar_res)
+  cscalar_res <- 0
+  cans <- cfoo(x, cscalar_res)
+  expect_identical(ans, cans)
+  expect_true(is.null(dim(cans)))
+  expect_equal(cans, 2L)
+  expect_identical(scalar_res, cscalar_res)
+  expect_identical(cscalar_res, 3*2L)
+  rm(ans, cans); gc()
 })
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR provides support for `obj[[varname]]` where `obj` is an nClass object and `varname` is a string to access a variable in C++ by *name* at *runtime*. This returns an `ETaccessorBase` (ET is for "Eigen Tensor". "Base" is for "base class".) That object can only be used through an `as` statement, e.g. `as(obj[[varname]], 'numericVector')`. Even if `obj[[varname]]` is not a `numericVector`, it will be handled as one if possible (i.e. if at runtime it is conformable to a vector, such as a higher dimensional tensor with all but one extent being 1). This PR also extends `as` to handle true scalar types as the input or output type.